### PR TITLE
FGD-31: Add language selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If you need to list changes to this changelog but there isn't an entry for it, c
 And list your changes under that.
 -->
 
+## [Unreleased] - Date Pending
+- (FGD-31) Adds a language picker to the composer for filtering/automatic translation purposes.
+
 ## [1.0-24 (beta)] - 30/1/2023
 
 ### Subscribed Tags

--- a/Fedigardens/Modules/Author/AuthorView.swift
+++ b/Fedigardens/Modules/Author/AuthorView.swift
@@ -26,6 +26,7 @@ struct AuthorView: View {
     @Environment(\.dismiss) var dismiss
 
     @Environment(\.userProfile) var userProfile
+    @Environment(\.locale) var locale
 
     /// The ID of the status that the current status will respond to, if the user is replying.
     ///
@@ -100,6 +101,7 @@ struct AuthorView: View {
                 .keyboardShortcut(.init(.escape, modifiers: .command))
                 .labelStyle(.titleOnly)
             }
+
             ToolbarItem(placement: .confirmationAction) {
                 Button {
                     Task {
@@ -114,6 +116,17 @@ struct AuthorView: View {
                 .keyboardShortcut(.init(.return, modifiers: [.command]))
                 .tint(.accentColor)
                 .disabled(viewModel.charactersRemaining < 0)
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                Picker(selection: $viewModel.selectedLanguage) {
+                    ForEach(NSLocale.isoLanguageCodes, id: \.hashValue) { code in
+                        Text(locale.localizedString(forLanguageCode: code) ?? "?")
+                            .tag(code)
+                    }
+                } label: {
+                    Label("status.languagecode", systemImage: "globe")
+                }
             }
         }
         .onContinueUserActivity("app.fedigardens.mail.authorscene", perform: continueActivity)

--- a/Fedigardens/Modules/Author/AuthorViewModel.swift
+++ b/Fedigardens/Modules/Author/AuthorViewModel.swift
@@ -36,6 +36,8 @@ class AuthorViewModel: ObservableObject {
     /// Associated warning text with a sensitive status context.
     @Published var sensitiveText = ""
 
+    @Published var selectedLanguage = "en"
+
     @Published var mentionString = ""
 
     var userProfile: Account?
@@ -77,7 +79,8 @@ class AuthorViewModel: ObservableObject {
         var params = [
             "status": mentionString.isNotEmpty ? "\(mentionString) \(text)" : text,
             "visibility": visibility.rawValue,
-            "poll": "null"
+            "poll": "null",
+            "language": selectedLanguage
         ]
         if let reply = prompt { params["in_reply_to_id"] = reply.id }
 

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -92,6 +92,7 @@
 "status.tagandreply.title" = "You have hashtags in your reply.";
 "status.tagandreply.detail" = "Remember to respect the person you are replying to, and refrain from adding hashtags for reach without consent. [Learn more…](https://fedigardens.app/support/#tags-in-replies)";
 "status.participants.empty" = "No participants";
+"status.languagecode" = "Select a Language";
 
 // MARK: - Status Actions
 "status.compose" = "New Status";


### PR DESCRIPTION
Implements requested changes in FGD-31 as one of the first "bottom bar" items. Uses all the language codes available in NSLocale.isoLanguageCodes.