### PR TITLE
FGD-8: Add attachments viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ And list your changes under that.
 - Moves the Mark as Sensitive toggle into the bottom toolbar in the composer.
 - Adds more keyboard shortcuts in the composer and other places of the app.
 - (FGD-20) Adds the ability to edit existing statuses in the composer.
+- (FGD-8) Adds attachment viewer to view images, videos, and other attachments.
 
 ## [1.0-24 (beta)] - 30/1/2023
 

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -1486,6 +1486,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Capstone--iOS--Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Feidgardens uses this access to save images to your device.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fedigardens uses this access to help you upload images and video from your library.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -1519,6 +1521,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Capstone--iOS--Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Feidgardens uses this access to save images to your device.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fedigardens uses this access to help you upload images and video from your library.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		95CDCD262990297E002BD37A /* AttachmentMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2129902968002BD37A /* AttachmentMedia.swift */; };
 		95CDCD2829904E19002BD37A /* AttachmentViewerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */; };
 		95CDCD2A29905085002BD37A /* GiantAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2929905085002BD37A /* GiantAlert.swift */; };
+		95CDCD2B29906548002BD37A /* AttachmentViewerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */; };
 		95CEFDE82959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDEB295A031E00EEE96C /* Pip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDEA295A031E00EEE96C /* Pip.swift */; };
@@ -1332,6 +1333,7 @@
 				95801D66297CC14200FE8D83 /* ProfileSheetRecentActivityView.swift in Sources */,
 				95801D54297CC10700FE8D83 /* InteractionsListViewModel.swift in Sources */,
 				955F1B522985FBE100702BE8 /* ProfileSheetLabel.swift in Sources */,
+				95CDCD2B29906548002BD37A /* AttachmentViewerToolbar.swift in Sources */,
 				95801D6B297CC14E00FE8D83 /* StatusView.swift in Sources */,
 				95801D6D297CC14E00FE8D83 /* StatusQuickGlanceView.swift in Sources */,
 				951365AC298ED3B8008F6D47 /* AuthorViewToolbar.swift in Sources */,

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		95CDCD242990297E002BD37A /* AttachmentMediaGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CD2957FD94005C7F2A /* AttachmentMediaGroup.swift */; };
 		95CDCD252990297E002BD37A /* AttachmentViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D28C74299024FE0051D31E /* AttachmentViewer.swift */; };
 		95CDCD262990297E002BD37A /* AttachmentMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2129902968002BD37A /* AttachmentMedia.swift */; };
+		95CDCD2829904E19002BD37A /* AttachmentViewerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */; };
 		95CEFDE82959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDEB295A031E00EEE96C /* Pip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDEA295A031E00EEE96C /* Pip.swift */; };
@@ -408,6 +409,7 @@
 		95CD3C4E29650A600043CDB2 /* GardensViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardensViewModel.swift; sourceTree = "<group>"; };
 		95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViewerViewModel.swift; sourceTree = "<group>"; };
 		95CDCD2129902968002BD37A /* AttachmentMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMedia.swift; sourceTree = "<group>"; };
+		95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViewerToolbar.swift; sourceTree = "<group>"; };
 		95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusVerifiedButton.swift; sourceTree = "<group>"; };
 		95CEFDEA295A031E00EEE96C /* Pip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pip.swift; sourceTree = "<group>"; };
 		95CEFDED295A388100EEE96C /* StatusDetailQuote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetailQuote.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				95D28C74299024FE0051D31E /* AttachmentViewer.swift */,
 				95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */,
 				95CDCD2129902968002BD37A /* AttachmentMedia.swift */,
+				95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */,
 			);
 			path = "Media Viewer";
 			sourceTree = "<group>";
@@ -1107,6 +1110,7 @@
 				95009EF2295E711100F32F85 /* AuthenticationViewModel.swift in Sources */,
 				9537C6D6297DBB510039F3C4 /* SettingsBlocklistViewModel.swift in Sources */,
 				95F2DE26297262D700553937 /* SettingsInterventionPage.swift in Sources */,
+				95CDCD2829904E19002BD37A /* AttachmentViewerToolbar.swift in Sources */,
 				956714162958C1BF00BFF76A /* AuthoringScene.swift in Sources */,
 				953BC7CB2957EC27005C7F2A /* HashableType.swift in Sources */,
 				955F1B342985C1D600702BE8 /* SearchResultsView.swift in Sources */,

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		95CDCD2829904E19002BD37A /* AttachmentViewerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */; };
 		95CDCD2A29905085002BD37A /* GiantAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2929905085002BD37A /* GiantAlert.swift */; };
 		95CDCD2B29906548002BD37A /* AttachmentViewerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */; };
+		95CDCD2C299066B5002BD37A /* GiantAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2929905085002BD37A /* GiantAlert.swift */; };
 		95CEFDE82959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDEB295A031E00EEE96C /* Pip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDEA295A031E00EEE96C /* Pip.swift */; };
@@ -1318,6 +1319,7 @@
 				95801D5F297CC13C00FE8D83 /* MessagingList.swift in Sources */,
 				95801D2B297C756200FE8D83 /* Collection+IsNotEmpty.swift in Sources */,
 				95801D57297CC13400FE8D83 /* StatusContextProvider.swift in Sources */,
+				95CDCD2C299066B5002BD37A /* GiantAlert.swift in Sources */,
 				95801D27297C752000FE8D83 /* Bundle+AppVersion.swift in Sources */,
 				95801D3E297CC0B600FE8D83 /* SettingsInterventionPage.swift in Sources */,
 				9537C6E0297DED820039F3C4 /* InterventionAllowedMechanisms.swift in Sources */,

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		95CDCD252990297E002BD37A /* AttachmentViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D28C74299024FE0051D31E /* AttachmentViewer.swift */; };
 		95CDCD262990297E002BD37A /* AttachmentMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2129902968002BD37A /* AttachmentMedia.swift */; };
 		95CDCD2829904E19002BD37A /* AttachmentViewerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */; };
+		95CDCD2A29905085002BD37A /* GiantAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2929905085002BD37A /* GiantAlert.swift */; };
 		95CEFDE82959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDEB295A031E00EEE96C /* Pip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDEA295A031E00EEE96C /* Pip.swift */; };
@@ -410,6 +411,7 @@
 		95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViewerViewModel.swift; sourceTree = "<group>"; };
 		95CDCD2129902968002BD37A /* AttachmentMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMedia.swift; sourceTree = "<group>"; };
 		95CDCD2729904E19002BD37A /* AttachmentViewerToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViewerToolbar.swift; sourceTree = "<group>"; };
+		95CDCD2929905085002BD37A /* GiantAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiantAlert.swift; sourceTree = "<group>"; };
 		95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusVerifiedButton.swift; sourceTree = "<group>"; };
 		95CEFDEA295A031E00EEE96C /* Pip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pip.swift; sourceTree = "<group>"; };
 		95CEFDED295A388100EEE96C /* StatusDetailQuote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetailQuote.swift; sourceTree = "<group>"; };
@@ -635,6 +637,7 @@
 				953BC7C72957E156005C7F2A /* RecursiveNavigationView.swift */,
 				95F2DE2329725C6100553937 /* BetaBadge.swift */,
 				955F1B532985FD1500702BE8 /* BadgedText.swift */,
+				95CDCD2929905085002BD37A /* GiantAlert.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1184,6 +1187,7 @@
 				955F1B4B2985F3A300702BE8 /* TagHistoryChart.swift in Sources */,
 				95369B5D27B82E7D00F39531 /* LayoutStateRepresentable.swift in Sources */,
 				95CEFDF2295A3B4900EEE96C /* StatusAuthorExtendedLabel.swift in Sources */,
+				95CDCD2A29905085002BD37A /* GiantAlert.swift in Sources */,
 				95009EF4295E780A00F32F85 /* GardensAppLayoutViewModel.swift in Sources */,
 				953BC7C82957E156005C7F2A /* RecursiveNavigationView.swift in Sources */,
 				953BC7CE2957FD94005C7F2A /* AttachmentMediaGroup.swift in Sources */,

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -36,8 +36,7 @@
 		953BC7C82957E156005C7F2A /* RecursiveNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7C72957E156005C7F2A /* RecursiveNavigationView.swift */; };
 		953BC7CB2957EC27005C7F2A /* HashableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CA2957EC27005C7F2A /* HashableType.swift */; };
 		953BC7CC2957EC27005C7F2A /* HashableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CA2957EC27005C7F2A /* HashableType.swift */; };
-		953BC7CE2957FD94005C7F2A /* StatusMediaDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CD2957FD94005C7F2A /* StatusMediaDrawer.swift */; };
-		953BC7CF2957FD94005C7F2A /* StatusMediaDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CD2957FD94005C7F2A /* StatusMediaDrawer.swift */; };
+		953BC7CE2957FD94005C7F2A /* AttachmentMediaGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CD2957FD94005C7F2A /* AttachmentMediaGroup.swift */; };
 		953DE4D327D69C7D0043A357 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DE4D227D69C7D0043A357 /* Bundle+AppVersion.swift */; };
 		9547230627A0094000D1BA89 /* Gardens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954722F627A0093F00D1BA89 /* Gardens.swift */; };
 		9547230827A0094000D1BA89 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954722F727A0093F00D1BA89 /* ContentView.swift */; };
@@ -253,6 +252,7 @@
 		95D1036C27A00AF000B1EE3C /* License.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 95D1036B27A00AF000B1EE3C /* License.pdf */; };
 		95D2704E27C6F5A200805262 /* MessagingListCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D2704D27C6F5A200805262 /* MessagingListCellView.swift */; };
 		95D2705127C6FEFA00805262 /* MessagingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D2705027C6FEFA00805262 /* MessagingList.swift */; };
+		95D28C75299024FE0051D31E /* AttachmentViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D28C74299024FE0051D31E /* AttachmentViewer.swift */; };
 		95D3E521295FD36800800FE6 /* Disallow.plist in Resources */ = {isa = PBXBuildFile; fileRef = 95D3E520295FD36800800FE6 /* Disallow.plist */; };
 		95D3EADD27BBE51F00AF33D9 /* AuthorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D3EADC27BBE51F00AF33D9 /* AuthorView.swift */; };
 		95E4531F27D7B49C00572758 /* AuthenticationBrowserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E4531E27D7B49C00572758 /* AuthenticationBrowserWindow.swift */; };
@@ -297,7 +297,7 @@
 		953BC7C42957C73E005C7F2A /* StatusDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetailViewModel.swift; sourceTree = "<group>"; };
 		953BC7C72957E156005C7F2A /* RecursiveNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveNavigationView.swift; sourceTree = "<group>"; };
 		953BC7CA2957EC27005C7F2A /* HashableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashableType.swift; sourceTree = "<group>"; };
-		953BC7CD2957FD94005C7F2A /* StatusMediaDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMediaDrawer.swift; sourceTree = "<group>"; };
+		953BC7CD2957FD94005C7F2A /* AttachmentMediaGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMediaGroup.swift; sourceTree = "<group>"; };
 		953DE4CB27D662450043A357 /* .swiftformat */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftformat; path = ../.swiftformat; sourceTree = "<group>"; };
 		953DE4CE27D66BEF0043A357 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; name = .swiftlint.yml; path = ../.swiftlint.yml; sourceTree = "<group>"; };
 		953DE4D227D69C7D0043A357 /* Bundle+AppVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+AppVersion.swift"; sourceTree = "<group>"; };
@@ -408,6 +408,7 @@
 		95D1036B27A00AF000B1EE3C /* License.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = License.pdf; sourceTree = "<group>"; };
 		95D2704D27C6F5A200805262 /* MessagingListCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingListCellView.swift; sourceTree = "<group>"; };
 		95D2705027C6FEFA00805262 /* MessagingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingList.swift; sourceTree = "<group>"; };
+		95D28C74299024FE0051D31E /* AttachmentViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViewer.swift; sourceTree = "<group>"; };
 		95D3E520295FD36800800FE6 /* Disallow.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Disallow.plist; sourceTree = "<group>"; };
 		95D3EADC27BBE51F00AF33D9 /* AuthorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorView.swift; sourceTree = "<group>"; };
 		95E4531E27D7B49C00572758 /* AuthenticationBrowserWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationBrowserWindow.swift; sourceTree = "<group>"; };
@@ -599,7 +600,6 @@
 			isa = PBXGroup;
 			children = (
 				956714132958B69D00BFF76A /* StatusDisclosedContent.swift */,
-				953BC7CD2957FD94005C7F2A /* StatusMediaDrawer.swift */,
 				957AF84E29591B44000370E6 /* StatusPollView.swift */,
 				95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */,
 				95CEFDF1295A3B4900EEE96C /* StatusAuthorExtendedLabel.swift */,
@@ -822,6 +822,7 @@
 				958E208E2969F7E0008AE63F /* Interactions */,
 				95CD3C4B296509260043CDB2 /* Intervention */,
 				95ADAE1D27B6DB830011FD83 /* Layout */,
+				95D28C73299024C50051D31E /* Media Viewer */,
 				952A010F27C67F1400F36B37 /* Messaging */,
 				95A1BF9629738A61002C88B6 /* Profiles */,
 				955F1B2629859D7600702BE8 /* Search */,
@@ -882,6 +883,15 @@
 				95D3E520295FD36800800FE6 /* Disallow.plist */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		95D28C73299024C50051D31E /* Media Viewer */ = {
+			isa = PBXGroup;
+			children = (
+				953BC7CD2957FD94005C7F2A /* AttachmentMediaGroup.swift */,
+				95D28C74299024FE0051D31E /* AttachmentViewer.swift */,
+			);
+			path = "Media Viewer";
 			sourceTree = "<group>";
 		};
 		95E4531D27D7B48800572758 /* Authentication */ = {
@@ -1096,6 +1106,7 @@
 				95645BD727C5550B00FB3426 /* SettingsView.swift in Sources */,
 				958E20922969F9FC008AE63F /* InteractionsListViewModel.swift in Sources */,
 				95801D33297C9B6E00FE8D83 /* Visibility+Localization.swift in Sources */,
+				95D28C75299024FE0051D31E /* AttachmentViewer.swift in Sources */,
 				95CEFDEB295A031E00EEE96C /* Pip.swift in Sources */,
 				955F1B572985FE0100702BE8 /* ProfileSheetFields.swift in Sources */,
 				95A36E96297CEEC900DA11D3 /* GardensAppCompactSidebarContent.swift in Sources */,
@@ -1160,7 +1171,7 @@
 				95CEFDF2295A3B4900EEE96C /* StatusAuthorExtendedLabel.swift in Sources */,
 				95009EF4295E780A00F32F85 /* GardensAppLayoutViewModel.swift in Sources */,
 				953BC7C82957E156005C7F2A /* RecursiveNavigationView.swift in Sources */,
-				953BC7CE2957FD94005C7F2A /* StatusMediaDrawer.swift in Sources */,
+				953BC7CE2957FD94005C7F2A /* AttachmentMediaGroup.swift in Sources */,
 				952A06E329691C3D008340A4 /* GardensAppPage.swift in Sources */,
 				95ADAE1A27B6D9740011FD83 /* StatusNavigationList.swift in Sources */,
 				95801D39297CAC8B00FE8D83 /* SettingsAboutPage.swift in Sources */,
@@ -1206,7 +1217,6 @@
 				955F1B2C29859FA300702BE8 /* SearchViewModel.swift in Sources */,
 				955F1B3C2985D74100702BE8 /* SearchAccountView.swift in Sources */,
 				95801D53297CC10700FE8D83 /* ContentView.swift in Sources */,
-				953BC7CF2957FD94005C7F2A /* StatusMediaDrawer.swift in Sources */,
 				957AF85329592DD1000370E6 /* AuthoringContext.swift in Sources */,
 				95801D50297CC10700FE8D83 /* GardensAppWideLayout.swift in Sources */,
 				95801D56297CC13400FE8D83 /* StatusNavigationListViewModel.swift in Sources */,

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -242,6 +242,12 @@
 		95CC7593295BEBC600629798 /* MessagingDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CC7592295BEBC600629798 /* MessagingDetailViewModel.swift */; };
 		95CD3C4D296509470043CDB2 /* InterventionAuthorizationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CD3C4C296509470043CDB2 /* InterventionAuthorizationContext.swift */; };
 		95CD3C4F29650A600043CDB2 /* GardensViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CD3C4E29650A600043CDB2 /* GardensViewModel.swift */; };
+		95CDCD20299027FC002BD37A /* AttachmentViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */; };
+		95CDCD2229902968002BD37A /* AttachmentMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2129902968002BD37A /* AttachmentMedia.swift */; };
+		95CDCD232990297E002BD37A /* AttachmentViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */; };
+		95CDCD242990297E002BD37A /* AttachmentMediaGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC7CD2957FD94005C7F2A /* AttachmentMediaGroup.swift */; };
+		95CDCD252990297E002BD37A /* AttachmentViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D28C74299024FE0051D31E /* AttachmentViewer.swift */; };
+		95CDCD262990297E002BD37A /* AttachmentMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CDCD2129902968002BD37A /* AttachmentMedia.swift */; };
 		95CEFDE82959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */; };
 		95CEFDEB295A031E00EEE96C /* Pip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEFDEA295A031E00EEE96C /* Pip.swift */; };
@@ -400,6 +406,8 @@
 		95CC7592295BEBC600629798 /* MessagingDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingDetailViewModel.swift; sourceTree = "<group>"; };
 		95CD3C4C296509470043CDB2 /* InterventionAuthorizationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterventionAuthorizationContext.swift; sourceTree = "<group>"; };
 		95CD3C4E29650A600043CDB2 /* GardensViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardensViewModel.swift; sourceTree = "<group>"; };
+		95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViewerViewModel.swift; sourceTree = "<group>"; };
+		95CDCD2129902968002BD37A /* AttachmentMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMedia.swift; sourceTree = "<group>"; };
 		95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusVerifiedButton.swift; sourceTree = "<group>"; };
 		95CEFDEA295A031E00EEE96C /* Pip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pip.swift; sourceTree = "<group>"; };
 		95CEFDED295A388100EEE96C /* StatusDetailQuote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetailQuote.swift; sourceTree = "<group>"; };
@@ -890,6 +898,8 @@
 			children = (
 				953BC7CD2957FD94005C7F2A /* AttachmentMediaGroup.swift */,
 				95D28C74299024FE0051D31E /* AttachmentViewer.swift */,
+				95CDCD1F299027FC002BD37A /* AttachmentViewerViewModel.swift */,
+				95CDCD2129902968002BD37A /* AttachmentMedia.swift */,
 			);
 			path = "Media Viewer";
 			sourceTree = "<group>";
@@ -1121,6 +1131,7 @@
 				95E4531F27D7B49C00572758 /* AuthenticationBrowserWindow.swift in Sources */,
 				955F1B2B29859FA300702BE8 /* SearchViewModel.swift in Sources */,
 				95ADADE427B6A6BB0011FD83 /* String+AttributedContent.swift in Sources */,
+				95CDCD2229902968002BD37A /* AttachmentMedia.swift in Sources */,
 				95B368A12965106C00336284 /* URL+CustomInits.swift in Sources */,
 				95ADAE0A27B6B49A0011FD83 /* JSONDecoder+Resources.swift in Sources */,
 				955F1B632986FBBE00702BE8 /* SettingsLicensePage.swift in Sources */,
@@ -1176,6 +1187,7 @@
 				95ADAE1A27B6D9740011FD83 /* StatusNavigationList.swift in Sources */,
 				95801D39297CAC8B00FE8D83 /* SettingsAboutPage.swift in Sources */,
 				955F1B412985E6E100702BE8 /* SearchTagResultPage.swift in Sources */,
+				95CDCD20299027FC002BD37A /* AttachmentViewerViewModel.swift in Sources */,
 				957AF855295937CF000370E6 /* AuthorViewModel.swift in Sources */,
 				95667E7A27B85C3B009D2251 /* MockData.swift in Sources */,
 				95CC7593295BEBC600629798 /* MessagingDetailViewModel.swift in Sources */,
@@ -1235,8 +1247,10 @@
 				95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */,
 				95801D59297CC13400FE8D83 /* StatusDetailProfileMenu.swift in Sources */,
 				957AF85029591B44000370E6 /* StatusPollView.swift in Sources */,
+				95CDCD232990297E002BD37A /* AttachmentViewerViewModel.swift in Sources */,
 				95801D60297CC13C00FE8D83 /* MessagingAuthorView.swift in Sources */,
 				958C0C9927BE930D00ED6C23 /* Account+AccountName.swift in Sources */,
+				95CDCD252990297E002BD37A /* AttachmentViewer.swift in Sources */,
 				955F1B2929859E0600702BE8 /* SearchView.swift in Sources */,
 				955F1B612986FB4800702BE8 /* SettingsFeedbackSection.swift in Sources */,
 				95801D26297C751C00FE8D83 /* String+AttributedContent.swift in Sources */,
@@ -1249,6 +1263,7 @@
 				95801D6C297CC14E00FE8D83 /* StatusAuthorExtendedLabel.swift in Sources */,
 				955F1B4F2985FB9E00702BE8 /* ProfileSheetStatistics.swift in Sources */,
 				95ADADFE27B6A9730011FD83 /* Shared.swift in Sources */,
+				95CDCD242990297E002BD37A /* AttachmentMediaGroup.swift in Sources */,
 				95801D6F297CC15900FE8D83 /* Acknowledgement+License.swift in Sources */,
 				95801D3A297CAC8B00FE8D83 /* SettingsAboutPage.swift in Sources */,
 				955F1B492985EDB300702BE8 /* Tag+Chartable.swift in Sources */,
@@ -1263,6 +1278,7 @@
 				95A36E97297CEEC900DA11D3 /* GardensAppCompactSidebarContent.swift in Sources */,
 				95801D4D297CC10700FE8D83 /* GardensAppPage.swift in Sources */,
 				95801D68297CC14200FE8D83 /* ProfileSheetViewModel.swift in Sources */,
+				95CDCD262990297E002BD37A /* AttachmentMedia.swift in Sources */,
 				9537C6DA297DC71C0039F3C4 /* SettingsReadingPage.swift in Sources */,
 				95801D34297C9B6E00FE8D83 /* Visibility+Localization.swift in Sources */,
 				95801D2A297C755200FE8D83 /* LayoutStateRepresentable.swift in Sources */,

--- a/Fedigardens/Modules/Components/GiantAlert.swift
+++ b/Fedigardens/Modules/Components/GiantAlert.swift
@@ -1,0 +1,147 @@
+//
+//  GiantAlert.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 2/5/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+
+struct GiantAlert<Icon: View, Actions: View, Message: View>: View {
+    @Environment(\.dismiss) var dismissAction
+    var title: LocalizedStringKey
+    var icon: () -> Icon?
+    var actions: () -> Actions
+    var message: () -> Message?
+
+    init(
+        title: LocalizedStringKey,
+        @ViewBuilder icon: @escaping () -> Icon? = { nil },
+        @ViewBuilder actions: @escaping () -> Actions,
+        @ViewBuilder message: @escaping () -> Message? = { nil }
+    ) {
+        self.title = title
+        self.actions = actions
+        self.message = message
+        self.icon = icon
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let icon {
+                icon()
+                    .font(.largeTitle)
+                    .imageScale(.large)
+                    .padding(.top)
+            }
+            Text(title)
+                .font(.largeTitle)
+                .bold()
+            ScrollView(.vertical) {
+                if let message {
+                    message()
+                } else {
+                    defaultMessage
+                }
+            }
+            Spacer()
+            Group {
+                actions()
+            }
+            .controlSize(.large)
+        }
+        .padding()
+    }
+
+    private var defaultMessage: some View {
+        EmptyView()
+    }
+}
+
+struct GiantAlertModifier<Icon: View, Actions: View, Message: View>: ViewModifier {
+    var isPresented: Binding<Bool>
+    var title: LocalizedStringKey
+    var icon: (() -> Icon)?
+    var actions: () -> Actions
+    var message: (() -> Message)?
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: isPresented) {
+                GiantAlert(
+                    title: title,
+                    icon: icon ?? { nil },
+                    actions: actions,
+                    message: message ?? { nil }
+                )
+            }
+    }
+}
+
+extension View {
+    func giantAlert<I: View, A: View, M: View>(
+        isPresented: Binding<Bool>,
+        title: LocalizedStringKey,
+        @ViewBuilder icon: @escaping () -> I? = { nil },
+        @ViewBuilder actions: @escaping () -> A,
+        @ViewBuilder message: @escaping () -> M? = { nil }
+    ) -> some View {
+        self.modifier(
+            GiantAlertModifier(
+                isPresented: isPresented,
+                title: title,
+                icon: icon,
+                actions: actions,
+                message: message
+            )
+        )
+    }
+}
+
+struct GiantAlertTestView: View {
+    @State private var pressed = false
+
+    var body: some View {
+        VStack {
+            Button {
+                pressed.toggle()
+            } label: {
+                Text("Press Me")
+            }
+        }
+        .giantAlert(isPresented: $pressed, title: "attachments.share.title") {
+            Image(systemName: "square.and.arrow.up")
+        } actions: {
+            Button {
+                pressed = false
+            } label: {
+                Text("attachments.share.acknowledge")
+                    .bold()
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            Button(role: .cancel) {
+                pressed = false
+            } label: {
+                Text("general.cancel")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        } message: {
+            Text("attachments.share.detail")
+        }
+    }
+}
+
+struct GiantAlert_Previews: PreviewProvider {
+    static var previews: some View {
+        GiantAlertTestView()
+    }
+}

--- a/Fedigardens/Modules/Layout/Status Detail View/Components/StatusDetailToolbar.swift
+++ b/Fedigardens/Modules/Layout/Status Detail View/Components/StatusDetailToolbar.swift
@@ -145,6 +145,18 @@ struct StatusDetailToolbar: CustomizableToolbarContent {
                     }
                 }
             }
+            ToolbarItem(id: "view-attachments", placement: .primaryAction) {
+                Group {
+                    let allAttached = viewModel.status?.reblog?.mediaAttachments ?? viewModel.status?.mediaAttachments
+                    Button {
+                        if let attachments = allAttached, let id = viewModel.status?.id {
+                            viewModel.displayAttachments = .init(id: id, attachments: attachments)
+                        }
+                    } label: {
+                        Label("status.attachmentaction", systemImage: "paperclip")
+                    }.disabled(allAttached == nil || allAttached?.isEmpty == true)
+                }
+            }
         }
     }
 

--- a/Fedigardens/Modules/Layout/Status Detail View/StatusDetailView.swift
+++ b/Fedigardens/Modules/Layout/Status Detail View/StatusDetailView.swift
@@ -149,6 +149,11 @@ struct StatusDetailView: View {
                 ProfileSheetView(profile: profile)
             }
         }
+        .fullScreenCover(item: $viewModel.displayAttachments) {
+            viewModel.displayAttachments = nil
+        } content: { context in
+            AttachmentViewer(attachments: context.attachments)
+        }
     }
 }
 

--- a/Fedigardens/Modules/Layout/Status Detail View/StatusDetailViewModel.swift
+++ b/Fedigardens/Modules/Layout/Status Detail View/StatusDetailViewModel.swift
@@ -24,12 +24,18 @@ class StatusDetailViewModel: ObservableObject {
         var status: Status
     }
 
+    struct AttachmentContextCaller: Hashable, Identifiable {
+        var id: String
+        var attachments: [Attachment]
+    }
+
     @Published var status: Status?
     @Published var quote: Status?
     @Published var quoteSource: Status.QuoteSource?
     @Published var context: Context?
     @Published var shouldOpenCompositionTool: AuthoringContext?
     @Published var expandAncestors = false
+    @Published var displayAttachments: AttachmentContextCaller?
     @Published var state = LayoutState.initial
     @Published var displayedProfile: Account?
 

--- a/Fedigardens/Modules/Media Viewer/AttachmentMedia.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentMedia.swift
@@ -1,0 +1,75 @@
+//
+//  AttachmentMedia.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 2/5/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import AVKit
+import SwiftUI
+import Alice
+
+struct AttachmentMedia: View {
+    var attachment: Attachment
+
+    var body: some View {
+        Group {
+            switch attachment.type {
+            case .image:
+                image(of: attachment)
+            case .video, .gifv:
+                VideoPlayer(player: videoPlayer(for: attachment.url)) {
+                    VStack {
+                        HStack {
+                            Image(systemName: "play.fill")
+                                .imageScale(.large)
+                            Spacer()
+                        }
+                        .foregroundColor(.white)
+                        Spacer()
+                    }.padding()
+                }
+                .aspectRatio(3/2, contentMode: .fill)
+            default:
+                Label("Unidentified attachments", systemImage: "questionmark.circle")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+                    .bold()
+            }
+        }
+    }
+
+    private func image(of attachment: Attachment) -> some View {
+        AsyncImage(url: .init(string: attachment.url)!) { image in
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.black)
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .aspectRatio(3/2, contentMode: .fill)
+            }
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.secondary.opacity(0.5))
+            )
+        } placeholder: {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.secondary.opacity(0.2))
+                .aspectRatio(3/2, contentMode: .fill)
+        }
+    }
+
+    private func videoPlayer(for resource: String) -> AVPlayer? {
+        guard let url = URL(string: resource) else { return nil }
+        return AVPlayer(url: url)
+    }
+}

--- a/Fedigardens/Modules/Media Viewer/AttachmentMediaGroup.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentMediaGroup.swift
@@ -31,59 +31,22 @@ struct AttachmentMediaGroup: View {
     var body: some View {
         LazyVGrid(columns: columns, spacing: 10) {
             ForEach(mediaAttachments) { (attachment: Attachment) in
-                Group {
-                    switch attachment.type {
-                    case .image:
-                        image(of: attachment)
-                    case .video, .gifv:
-                        VideoPlayer(player: videoPlayer(for: attachment.url)) {
-                            VStack {
-                                HStack {
-                                    Image(systemName: "play.fill")
-                                        .imageScale(.large)
-                                    Spacer()
-                                }
-                                .foregroundColor(.white)
-                                Spacer()
-                            }.padding()
-                        }
-                            .aspectRatio(3/2, contentMode: .fill)
-                    default:
-                        Label("Unidentified attachments", systemImage: "questionmark.circle")
-                            .font(.callout)
-                            .foregroundColor(.secondary)
-                            .bold()
-                    }
-                }
+                AttachmentMedia(attachment: attachment)
             }
         }
         .padding(.vertical)
     }
+}
 
-    private func image(of attachment: Attachment) -> some View {
-        AsyncImage(url: .init(string: attachment.url)!) { image in
-            ZStack {
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.black)
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .aspectRatio(3/2, contentMode: .fill)
-            }
-                .cornerRadius(10)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.secondary.opacity(0.5))
-                )
-        } placeholder: {
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.secondary.opacity(0.2))
-                .aspectRatio(3/2, contentMode: .fill)
+struct AttachmentMediaGroup_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            StatusView(status: MockData.status!)
+                .lineLimit(6)
+                .redacted(reason: .privacy)
+            AttachmentMediaGroup(status: MockData.status!)
+            Spacer()
         }
-    }
-
-    private func videoPlayer(for resource: String) -> AVPlayer? {
-        guard let url = URL(string: resource) else { return nil }
-        return AVPlayer(url: url)
+        .padding()
     }
 }

--- a/Fedigardens/Modules/Media Viewer/AttachmentMediaGroup.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentMediaGroup.swift
@@ -16,7 +16,7 @@ import SwiftUI
 import Alice
 import AVKit
 
-struct StatusMediaDrawer: View {
+struct AttachmentMediaGroup: View {
     var status: Status
 
     private var mediaAttachments: [Attachment] {

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
@@ -1,0 +1,28 @@
+//
+//  AttachmentViewer.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 2/5/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+import Alice
+
+struct AttachmentViewer: View {
+    var body: some View {
+        Image(systemName: "globe")
+    }
+}
+
+struct AttachmentViewer_Previews: PreviewProvider {
+    static var previews: some View {
+        AttachmentViewer()
+    }
+}

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
@@ -107,20 +107,32 @@ struct AttachmentViewer: View {
                         .font(.footnote)
                 }
             }
+            .padding()
         }
-        .alert("attachments.share.title", isPresented: $viewModel.shouldDisplayConsentAcknowledgementAlert) {
+        .giantAlert(
+            isPresented: $viewModel.shouldDisplayConsentAcknowledgementAlert,
+            title: "attachments.share.title"
+        ) {
+            Image(systemName: "square.and.arrow.up.trianglebadge.exclamationmark")
+        } actions: {
             Button {
                 viewModel.didAcknowledgeConsent = true
+                viewModel.shouldDisplayConsentAcknowledgementAlert = false
             } label: {
                 Text("attachments.share.acknowledge")
+                    .frame(maxWidth: .infinity)
             }
+            .buttonStyle(.bordered)
             Button(role: .cancel) {
-
+                viewModel.shouldDisplayConsentAcknowledgementAlert = false
             } label: {
-                Text("general.cancel")
+                Text("attachments.share.cancel")
+                    .bold()
+                    .frame(maxWidth: .infinity)
             }
+            .buttonStyle(.borderedProminent)
         } message: {
-             Text("attachments.share.detail")
+            Text("attachments.share.detail")
         }
         .toolbar {
             AttachmentViewerToolbar(viewModel: viewModel)

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
@@ -82,7 +82,9 @@ struct AttachmentViewer: View {
                 }
                 .padding()
                 .onAppear {
-                    viewModel.currentAttachment = attachment
+                    withAnimation(.easeInOut) {
+                        viewModel.currentAttachment = attachment
+                    }
                 }
             }
             .preferredColorScheme(.dark)
@@ -131,13 +133,16 @@ struct AttachmentViewer: View {
     private func preview(for attachment: Attachment) -> some View {
         Group {
             if let path = attachment.previewURL, let url = URL(string: path) {
-                AsyncImage(url: url) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .opacity(0.3)
-                } placeholder: {
-                    Color.black
+                AsyncImage(url: url, transaction: .init(animation: .easeInOut)) { (phase: AsyncImagePhase) in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .opacity(0.3)
+                    default:
+                        Color.black
+                    }
                 }
             }
         }

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
@@ -16,13 +16,72 @@ import SwiftUI
 import Alice
 
 struct AttachmentViewer: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = AttachmentViewerViewModel()
+    @GestureState private var scaleEffect = 1.0
+
+    var attachments: [Attachment]
+
+    private var zoomGesture: some Gesture {
+        MagnificationGesture()
+            .updating($scaleEffect) { currentState, gestureState, transaction in
+                withAnimation(transaction.animation) {
+                    gestureState = currentState
+                }
+            }
+    }
+
     var body: some View {
-        Image(systemName: "globe")
+        NavigationStack {
+            TabView {
+                ForEach(attachments, id: \.id) { attachment in
+                    AttachmentMedia(attachment: attachment)
+                        .aspectRatio(contentMode: viewModel.contentMode)
+                        .scaleEffect(scaleEffect)
+                        .gesture(zoomGesture)
+                        .safeAreaInset(edge: .bottom) {
+                            Text(attachment.description ?? "No description provided.")
+                                .font(.footnote)
+                        }
+                        .onAppear {
+                            viewModel.currentAttachment = attachment
+                        }
+                }
+                .preferredColorScheme(.dark)
+            }
+            .tabViewStyle(.page)
+            .background(Color.black)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: viewModel.toggleContentMode) {
+                        Label("", systemImage: viewModel.systemImageForContentMode())
+                    }
+                }
+                ToolbarItem {
+                    Group {
+                        if let url = viewModel.currentAttachment?.url {
+                            ShareLink(item: url)
+                        }
+                    }
+                }
+                ToolbarItem {
+                    Button(action: dismiss.callAsFunction) {
+                        Text("general.done")
+                            .bold()
+                    }
+                }
+            }
+        }
+        .animation(.spring(), value: viewModel.contentMode)
+        .onAppear {
+            viewModel.attachments = attachments
+        }
     }
 }
 
 struct AttachmentViewer_Previews: PreviewProvider {
     static var previews: some View {
-        AttachmentViewer()
+        AttachmentViewer(attachments: Array(repeating: MockData.status!.mediaAttachments.first!, count: 4))
     }
 }

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewer.swift
@@ -108,25 +108,22 @@ struct AttachmentViewer: View {
                 }
             }
         }
+        .alert("attachments.share.title", isPresented: $viewModel.shouldDisplayConsentAcknowledgementAlert) {
+            Button {
+                viewModel.didAcknowledgeConsent = true
+            } label: {
+                Text("attachments.share.acknowledge")
+            }
+            Button(role: .cancel) {
+
+            } label: {
+                Text("general.cancel")
+            }
+        } message: {
+             Text("attachments.share.detail")
+        }
         .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(action: viewModel.toggleContentMode) {
-                    Label("", systemImage: viewModel.systemImageForContentMode())
-                }
-            }
-            ToolbarItem {
-                Group {
-                    if let url = viewModel.currentAttachment?.url {
-                        ShareLink(item: url)
-                    }
-                }
-            }
-            ToolbarItem {
-                Button(action: dismiss.callAsFunction) {
-                    Text("general.done")
-                        .bold()
-                }
-            }
+            AttachmentViewerToolbar(viewModel: viewModel)
         }
     }
 

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewerToolbar.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewerToolbar.swift
@@ -1,0 +1,52 @@
+//
+//  AttachmentViewerToolbar.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 2/5/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+import Alice
+
+struct AttachmentViewerToolbar: ToolbarContent {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject var viewModel: AttachmentViewerViewModel
+    
+    var body: some ToolbarContent {
+        Group {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(action: viewModel.toggleContentMode) {
+                    Label("", systemImage: viewModel.systemImageForContentMode())
+                }
+            }
+            ToolbarItem {
+                Group {
+                    if viewModel.didAcknowledgeConsent {
+                        if let url = viewModel.currentAttachment?.url {
+                            ShareLink(item: url)
+                        }
+                    } else {
+                        Button {
+                            viewModel.shouldDisplayConsentAcknowledgementAlert.toggle()
+                        } label: {
+                            Label("general.share", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                }
+            }
+            ToolbarItem {
+                Button(action: dismiss.callAsFunction) {
+                    Text("general.done")
+                        .bold()
+                }
+            }
+        }
+    }
+}

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewerToolbar.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewerToolbar.swift
@@ -18,7 +18,7 @@ import Alice
 struct AttachmentViewerToolbar: ToolbarContent {
     @Environment(\.dismiss) private var dismiss
     @StateObject var viewModel: AttachmentViewerViewModel
-    
+
     var body: some ToolbarContent {
         Group {
             ToolbarItem(placement: .cancellationAction) {

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewerViewModel.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewerViewModel.swift
@@ -20,6 +20,7 @@ class AttachmentViewerViewModel: ObservableObject {
     @Published var currentAttachment: Attachment?
     @Published var attachments = [Attachment]()
     @Published var contentMode = ContentMode.fit
+    @Published var magnification = 1.0
 
     func toggleContentMode() {
         contentMode = (contentMode == .fit) ? .fill : .fit
@@ -27,9 +28,9 @@ class AttachmentViewerViewModel: ObservableObject {
 
     func systemImageForContentMode() -> String {
         switch contentMode {
-        case .fit:
-            return "arrow.down.right.and.arrow.up.left"
         case .fill:
+            return "arrow.down.right.and.arrow.up.left"
+        case .fit:
             return "arrow.up.left.and.arrow.down.right"
         }
     }

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewerViewModel.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewerViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  AttachmentViewerViewModel.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 2/5/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+import Combine
+import Alice
+
+class AttachmentViewerViewModel: ObservableObject {
+    @Published var currentAttachment: Attachment?
+    @Published var attachments = [Attachment]()
+    @Published var contentMode = ContentMode.fit
+
+    func toggleContentMode() {
+        contentMode = (contentMode == .fit) ? .fill : .fit
+    }
+
+    func systemImageForContentMode() -> String {
+        switch contentMode {
+        case .fit:
+            return "arrow.down.right.and.arrow.up.left"
+        case .fill:
+            return "arrow.up.left.and.arrow.down.right"
+        }
+    }
+}

--- a/Fedigardens/Modules/Media Viewer/AttachmentViewerViewModel.swift
+++ b/Fedigardens/Modules/Media Viewer/AttachmentViewerViewModel.swift
@@ -17,10 +17,12 @@ import Combine
 import Alice
 
 class AttachmentViewerViewModel: ObservableObject {
-    @Published var currentAttachment: Attachment?
     @Published var attachments = [Attachment]()
     @Published var contentMode = ContentMode.fit
+    @Published var currentAttachment: Attachment?
+    @Published var didAcknowledgeConsent = false
     @Published var magnification = 1.0
+    @Published var shouldDisplayConsentAcknowledgementAlert = false
 
     func toggleContentMode() {
         contentMode = (contentMode == .fit) ? .fill : .fit

--- a/Fedigardens/Modules/Statuses/Status Components/StatusDisclosedContent.swift
+++ b/Fedigardens/Modules/Statuses/Status Components/StatusDisclosedContent.swift
@@ -50,7 +50,7 @@ struct StatusDisclosedContent: View {
                     .textSelection(.enabled)
             }
             if truncateLines == nil {
-                StatusMediaDrawer(status: status)
+                AttachmentMediaGroup(status: status)
                 if let poll = status.poll {
                     StatusPollView(poll: poll)
                 }

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -184,6 +184,9 @@
 // MARK: - Attachments
 "attachments.description.missing" = "No description provided.";
 "attachments.empty.warning" = "No Attachments Available";
+"attachments.share.title" = "Share Responsibly";
+"attachments.share.detail" = "Some attachments may be held under copyright or may not be shareable without the author's consent. Remember to check with the author before sharing attachments elsewhere. Your instance administrator may also have additional rules regarding sharing attachments from your instance.";
+"attachments.share.acknowledge" = "Share Anyway";
 
 // MARK: - Settings
 "settings.section.about" = "About";

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -187,6 +187,7 @@
 "attachments.share.title" = "Share Responsibly";
 "attachments.share.detail" = "Some attachments may be held under copyright or may not be shareable without the author's consent. Remember to check with the author before sharing attachments elsewhere. Your instance administrator may also have additional rules regarding sharing attachments from your instance.";
 "attachments.share.acknowledge" = "Share Anyway";
+"attachments.share.cancel" = "Don't Share";
 
 // MARK: - Settings
 "settings.section.about" = "About";

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "status.reblogaction" = "Reblog";
 "status.saveaction" = "Bookmark";
 "status.webaction" = "Open in Safari";
+"status.attachmentaction" = "View Attachments";
 "status.profileaction.generic" = "View Profile";
 "status.profileaction" = "View %@'s Profile";
 "status.profileaction.name" = "Profiles";
@@ -179,6 +180,10 @@
 "help.quotestatus" = "Write a new post by quoting the current status.";
 "help.visibleprompt" = "Why am I seeing this?";
 "help.bookmark" = "Save this status for later.";
+
+// MARK: - Attachments
+"attachments.description.missing" = "No description provided.";
+"attachments.empty.warning" = "No Attachments Available";
 
 // MARK: - Settings
 "settings.section.about" = "About";


### PR DESCRIPTION
A basic attachment viewer has been implemented, which allows users to view images and video in greater detail. It supports basic functionality such as zooming, viewing descriptions/alternative text, and sharing the content. When sharing an attachment, a warning will appear that reminds the user to share responsibly and make sure they do so with consent of the original author.


https://user-images.githubusercontent.com/13445064/216849219-a834c2f4-1c09-4a89-b727-f013120c90a9.mp4

