### PR TITLE
FGD-22:  Add bad URL mitigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ If you need to list changes to this changelog but there isn't an entry for it, c
 And list your changes under that.
 -->
 
+## Unreleased - Date Pending
+- (FGD-22) Shows an alert if Alice cannot connect to the provided instance due to invalid characters.
+- Renamed Feedback Portal instances to Raceway.
+
 ## [1.0-33 (beta)] - 13/2/23
 
 ### Composer Updates

--- a/Fedigardens.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fedigardens.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/alicerunsonfedora/bunker.git",
         "state": {
           "branch": "root",
-          "revision": "580a61b6fc576a9014f94b380758720967c8f087",
+          "revision": "9f7ba80122b3f0ff525d13cf997ecaa8c2128d87",
           "version": null
         }
       },
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/divadretlaw/EmojiText",
         "state": {
           "branch": "main",
-          "revision": "263935972835482fe655d7ce44e101cc3fb463bf",
+          "revision": "1a906aa183228f1b5ddfb45de11e0c08fe833535",
           "version": null
         }
       },
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/kean/Nuke",
         "state": {
           "branch": null,
-          "revision": "67bd45931180f652159e3342575277a7f197b3ab",
-          "version": "11.6.2"
+          "revision": "33f7e93be5d4ec027d42af77a8ec4680d1862ad2",
+          "version": "11.6.4"
         }
       },
       {

--- a/Fedigardens/Modules/Authentication/AuthenticationView.swift
+++ b/Fedigardens/Modules/Authentication/AuthenticationView.swift
@@ -66,6 +66,22 @@ struct AuthenticationView: View {
         } message: {
             Text("auth.disallowed.message")
         }
+        .alert(viewModel.authenticationInvalidTitle, isPresented: $viewModel.authenticationDomainInvalid) {
+            Button {
+                if let url = viewModel.authenticationInvalidRacewayLink {
+                    openURL(url)
+                }
+            } label: {
+                Text("auth.badurl.racewaycta")
+            }
+            Button {
+
+            } label: {
+                Text("OK")
+            }.keyboardShortcut(.defaultAction)
+        } message: {
+            Text("auth.badurl.message")
+        }
     }
 
     /// The authentication button.

--- a/Fedigardens/Modules/Authentication/AuthenticationViewModel.swift
+++ b/Fedigardens/Modules/Authentication/AuthenticationViewModel.swift
@@ -15,6 +15,7 @@
 import Foundation
 import Combine
 import Alice
+import Bunker
 
 class AuthenticationViewModel: ObservableObject {
     typealias AuthenticationModule = Alice.OAuth
@@ -23,16 +24,22 @@ class AuthenticationViewModel: ObservableObject {
     @Published var authenticationAuthorizedURL: URL?
     @Published var displayAuthenticationDialog = false
     @Published var authenticationDomainRejected = false
+    @Published var authenticationDomainInvalid = false
 
     var authenticationState: AuthenticationModule.State {
         return authModule.authState
     }
 
     var authenticationRejectionTitle: String {
-        String(
-            format: NSLocalizedString("auth.disallowed.title", comment: "Disallowed domain"),
-            authenticationDomainName
-        )
+        return "auth.disallowed.title".localized(comment: "Disallowed domain", authenticationDomainName)
+    }
+
+    var authenticationInvalidTitle: String {
+        return "auth.badurl.title".localized(comment: "Invalid URL (FGD-22)", authenticationDomainName)
+    }
+
+    var authenticationInvalidRacewayLink: URL? {
+        URL(destination: .raceway(title: "Unable to sign into '\(authenticationDomainName)'"))
     }
 
     private var authModule: AuthenticationModule = .shared
@@ -57,6 +64,10 @@ class AuthenticationViewModel: ObservableObject {
             DispatchQueue.main.async {
                 self.authenticationAuthorizedURL = url
                 self.displayAuthenticationDialog.toggle()
+            }
+        } onBadURL: { _ in
+            DispatchQueue.main.async {
+                self.authenticationDomainInvalid.toggle()
             }
         }
     }

--- a/Fedigardens/Modules/Settings/SettingsFeedbackSection.swift
+++ b/Fedigardens/Modules/Settings/SettingsFeedbackSection.swift
@@ -19,7 +19,7 @@ struct SettingsFeedbackSection: View {
 
     var body: some View {
         Section {
-            if let url = URL(destination: .feedback) {
+            if let url = URL(destination: .raceway()) {
                 Link(destination: url) {
                     Label {
                         VStack(alignment: .leading) {

--- a/Fedigardens/Modules/Utilities/Extensions/URL+CustomInits.swift
+++ b/Fedigardens/Modules/Utilities/Extensions/URL+CustomInits.swift
@@ -20,7 +20,7 @@ extension URL {
         case oneSecSettings
         case ghBugs
         case github
-        case feedback
+        case raceway(title: String? = nil)
         case changelog
         case orion(String)
 
@@ -34,8 +34,9 @@ extension URL {
                 return "onesec://integrationsettings?appId=fedigardens"
             case .github:
                 return ghLink
-            case .feedback:
-                return "https://feedback.marquiskurt.net/composer?primary_tag=fedigardens"
+            case .raceway(let title):
+                let titleArgument = title?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                return "https://feedback.marquiskurt.net/composer?primary_tag=fedigardens&title='\(titleArgument)'"
             case .changelog:
                 return "https://fedigardens.app/changelog"
             case .ghBugs:
@@ -47,6 +48,7 @@ extension URL {
     }
 
     init?(destination: AppDestination) {
+        print(destination.absoluteString)
         self.init(string: destination.absoluteString)
     }
 

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -60,6 +60,9 @@
 "auth.footnote.create" = "Find an Instance &rsaquo;";
 "auth.disallowed.title" = "Cannot Sign In to '%@'";
 "auth.disallowed.message" = "Fedigardens cannot sign in to this instance because the developers cannot verify that this server moderates the content posted by its users.";
+"auth.badurl.title" = "Cannot Connect to '%@";
+"auth.badurl.message" = "The instance domain likely contains invalid URL characters. If the instance domain you provided contains legal characters, you can file a report on Raceway to help us diagnose the issue.";
+"auth.badurl.racewaycta" = "Report on Raceway";
 
 // MARK: - Timelines
 "timeline.inbox.focused" = "Focused";
@@ -267,7 +270,7 @@
 // MARK: - Settings: Feedback -
 "settings.feedback.message" = "Message Fedigardens…";
 "settings.feedback.personal" = "Start a Discussion…";
-"settings.feedback.personaldetail" = "Send a bug report or suggest a feature at feedback.marquiskurt.net.";
+"settings.feedback.personaldetail" = "Send a bug report or suggest a feature on Raceway.";
 "settings.feedback.bugreportdetail" = "Submit a traditional bug report through GitHub Issues.";
 
 // MARK: - Acknowledgements

--- a/Packages/Alice/Sources/Alice/Networking/AuthenticationModule.swift
+++ b/Packages/Alice/Sources/Alice/Networking/AuthenticationModule.swift
@@ -89,11 +89,18 @@ public class AuthenticationModule: ObservableObject {
     public func startOauthFlow(
         for instanceDomain: String,
         registeredAs app: RegisteredApplication = .default,
-        authHandler: ((URL) -> Void)? = nil
+        authHandler: ((URL) -> Void)? = nil,
+        onBadURL badURLHandler: ((String) -> Void)? = nil
     ) async {
 
         //  First, we initialize the keychain object
         let keychain = Keychain(service: Alice.OAuth.keychainService)
+
+        // Check if the URL is valid, and return if the URL can't be created.
+        if URL(string: "https://\(instanceDomain)") == nil {
+            badURLHandler?(instanceDomain)
+            return
+        }
 
         //  Then, we assign the domain of the instance we are working with.
         keychain["starlight_instance_domain"] = instanceDomain

--- a/Packages/Alice/Sources/Alice/alice.swift
+++ b/Packages/Alice/Sources/Alice/alice.swift
@@ -62,11 +62,7 @@ public class Alice: ObservableObject, CustomStringConvertible {
         ?? "mastodon.online"
 
     static public var apiURL: URL {
-        if instanceDomain.isEmpty {
-            instanceDomain = "mastodon.online"
-            return URL(string: "https://mastodon.online")!
-        }
-        return URL(string: "https://\(instanceDomain)")!
+        return URL(string: "https://\(instanceDomain)") ?? URL(string: "https://mastodon.online")!
     }
 
     /// Allows us to decode top-level values of the given type from the given JSON representation.


### PR DESCRIPTION
The URL object usually returns nil if the string it was generated from contains invalid characters or is an empty string. It is unclear which characters cause this issue, and I'd rather not implement telemetry.

Instead, this PR introduces a new handler to Alice.startOAuthFlow that fires when the URL object is found to be nil, giving the user an opportunity to file a report on Raceway to help diagnose FGD-22 more clearly.