### PR TITLE
FGD-40: Update SettingsLabelStyle

### DIFF
--- a/Fedigardens/Modules/Settings/Label+SettingsStyle.swift
+++ b/Fedigardens/Modules/Settings/Label+SettingsStyle.swift
@@ -24,10 +24,11 @@ struct SettingsLabelStyle: LabelStyle {
                 .imageScale(.small)
                 .foregroundColor(.white)
                 .background(
-                    RoundedRectangle(cornerRadius: 8 * size)
-                        .frame(width: 28 * size, height: 28 * size)
+                    RoundedRectangle(cornerRadius: 6 * size)
+                        .frame(width: 24 * size, height: 24 * size)
                         .foregroundColor(color)
                 )
+                .padding(.vertical, 4 * size)
         }
     }
 }
@@ -35,5 +36,27 @@ struct SettingsLabelStyle: LabelStyle {
 extension LabelStyle where Self == SettingsLabelStyle {
     static func settings(color: Color, size: CGFloat) -> Self {
         SettingsLabelStyle(color: color, size: size)
+    }
+}
+
+struct SettingsLabelPreview: View {
+    @ScaledMetric private var size = 1.0
+    var body: some View {
+        Form {
+            Label("Test", systemImage: "star.fill")
+                .labelStyle(.settings(color: .yellow, size: size))
+            Label("Test", systemImage: "square.and.pencil")
+                .labelStyle(.settings(color: .blue, size: size))
+            Label("Test", systemImage: "app.fill")
+                .labelStyle(.settings(color: .red, size: size))
+            Label("Test", systemImage: "square.and.arrow.up")
+                .labelStyle(.settings(color: .green, size: size))
+        }
+    }
+}
+
+struct SettingsLabelStyle_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsLabelPreview()
     }
 }


### PR DESCRIPTION
Some extra padding has been added around the icon itself, and the background rectangle has been trimmed down to 24x24 at its base. This should make these types of labels a bit better.

![image](https://user-images.githubusercontent.com/13445064/223572869-ada3b791-6079-4495-b463-147c416c233b.png)
