### PR TITLE
FGD-39: Add "Show User Handle In Timeline"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ If you need to list changes to this changelog but there isn't an entry for it, c
 And list your changes under that.
 -->
 
+## [Unreleased] - Date Pending
+
+- (FGD-39) Adds a new "Show User Handle In Timeline" toggle in Settings > Viewing that toggles whether a full user
+  handle is displayed in the timeline list.
+
 ## [1.0-34 (beta)] - 4/3/23
 
 - (FGD-22) Shows an alert if Alice cannot connect to the provided instance due to invalid characters.

--- a/Fedigardens/Modules/Components/Statuses/Status Components/StatusAuthorExtendedLabel.swift
+++ b/Fedigardens/Modules/Components/Statuses/Status Components/StatusAuthorExtendedLabel.swift
@@ -27,6 +27,7 @@ struct StatusAuthorExtendedLabel: View {
 
     var status: Status
     var placementPolicy: VerificationPlacementPolicy
+    var showUserHandle = true
 
     private var hasVerifiedAccount: Bool {
         if let reblog = status.reblog {
@@ -71,10 +72,12 @@ struct StatusAuthorExtendedLabel: View {
                         .foregroundColor(.indigo)
                 }
             }
-            Text("(@\(status.reblog?.account.acct ?? status.account.acct))")
-                .foregroundColor(.secondary)
-                .font(.system(.callout, design: .rounded))
-                .lineLimit(1)
+            if showUserHandle {
+                Text("(@\(status.reblog?.account.acct ?? status.account.acct))")
+                    .foregroundColor(.secondary)
+                    .font(.system(.callout, design: .rounded))
+                    .lineLimit(1)
+            }
             if isDevelopmentMember, placementPolicy == .underAuthorLabel {
                 developerLabel
             } else if hasVerifiedAccount, placementPolicy == .underAuthorLabel {

--- a/Fedigardens/Modules/Components/Statuses/StatusView.swift
+++ b/Fedigardens/Modules/Components/Statuses/StatusView.swift
@@ -39,6 +39,7 @@ struct StatusView: View {
 
     @Environment(\.customEmojis) var emojis
     @AppStorage("status.show-statistics") var showsStatistics: Bool = true
+    @AppStorage(.alwaysShowUserHandle) var showsUserHandle: Bool = true
 
     var status: Status
 
@@ -104,7 +105,11 @@ struct StatusView: View {
                     if profileImagePlacement == .byAuthorName { authorImage }
                     VStack(alignment: .leading) {
                         HStack(alignment: .top) {
-                            StatusAuthorExtendedLabel(status: status, placementPolicy: verifiedNoticePlacement)
+                            StatusAuthorExtendedLabel(
+                                status: status,
+                                placementPolicy: verifiedNoticePlacement,
+                                showUserHandle: truncateLines == nil || showsUserHandle
+                            )
                             if truncateLines != nil {
                                 if datePlacement == .automatic {
                                     Spacer()

--- a/Fedigardens/Modules/Settings/Pages/SettingsReadingPage.swift
+++ b/Fedigardens/Modules/Settings/Pages/SettingsReadingPage.swift
@@ -17,6 +17,7 @@ import SwiftUI
 struct SettingsReadingPage: View {
     @AppStorage(.useFocusedInbox) var hidesReblogsAndReplies = false
     @AppStorage(.showsStatistics) var showsStatistics: Bool = true
+    @AppStorage(.alwaysShowUserHandle) var alwaysShowsUserHandle: Bool = true
     @AppStorage(.loadLimit) var loadLimit: Int = 10
     @ScaledMetric private var size = 1.0
 
@@ -35,6 +36,9 @@ struct SettingsReadingPage: View {
             }
 
             Section {
+                Toggle(isOn: $alwaysShowsUserHandle) {
+                    Text("settings.showhandle.title")
+                }
                 Toggle(isOn: $showsStatistics) {
                     Text("settings.show-statistics.title")
                 }

--- a/Fedigardens/Modules/Settings/Preferences Access/GardensSettingsKey.swift
+++ b/Fedigardens/Modules/Settings/Preferences Access/GardensSettingsKey.swift
@@ -20,6 +20,7 @@ enum GardensSettingsKey: String {
     case loadLimit = "network.load-limit"
     case showsStatistics = "status.shows-statistics"
     case useFocusedInbox = "timeline.original-filter"
+    case alwaysShowUserHandle = "timeline.show-handles"
     case allowsInterventions = "health.interventions"
     case intervenesOnRefresh = "health.interventions.refresh"
     case intervenesOnFetch = "health.interventions.fetch"

--- a/Fedigardens/Modules/Settings/Preferences Access/UserDefaults+Settings.swift
+++ b/Fedigardens/Modules/Settings/Preferences Access/UserDefaults+Settings.swift
@@ -26,6 +26,11 @@ extension UserDefaults {
         set { setValue(newValue, forKey: .showsStatistics) }
     }
 
+    var alwaysShowUserHandle: Bool {
+        get { getValue(forKey: .alwaysShowUserHandle, default: true) }
+        set { setValue(newValue, forKey: .alwaysShowUserHandle) }
+    }
+
     var showOriginalPostsOnly: Bool {
         get { getValue(forKey: .useFocusedInbox, default: false) }
         set { setValue(newValue, forKey: .useFocusedInbox) }

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "settings.loadlimit.detail" = "When fetching statuses from Mastodon, batches will be limited to this size.";
 "settings.showoriginal.title" = "Use Focused Timeline";
 "settings.showoriginal.detail" = "Focused Timeline splits your timeline to filter out reblogged content and replies.";
+"settings.showhandle.title" = "Show User Handle In Timeline";
 "settings.signout.link" = "Sign Out…";
 "settings.signout.prompt" = "Sign Out";
 "settings.signout.title" = "Are you sure you want to sign out?";


### PR DESCRIPTION
This setting will let you dictate whether the full user handle will be displayed in the timeline list.



<details>
<summary>Screenshots</summary>

| ![Simulator Screen Shot - iPhone 14 - 2023-03-07 at 19 08 45](https://user-images.githubusercontent.com/13445064/223585358-99ba1a0e-e82f-4be7-80e7-0be757e2a175.png) |![Simulator Screen Shot - iPhone 14 - 2023-03-07 at 19 08 50](https://user-images.githubusercontent.com/13445064/223585361-f5dc9fcf-56f3-47a1-a28d-78c5cacd8d68.png) |
| - | - |

</details>