### PR TITLE
FGD-46: Display alt text in frugal mode

### DIFF
--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		9547230627A0094000D1BA89 /* Gardens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954722F627A0093F00D1BA89 /* Gardens.swift */; };
 		9547230827A0094000D1BA89 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954722F727A0093F00D1BA89 /* ContentView.swift */; };
 		9547230A27A0094000D1BA89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 954722F827A0094000D1BA89 /* Assets.xcassets */; };
+		954C95052A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */; };
+		954C95062A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */; };
 		95555FB32960B7A2005BEF45 /* AckGen in Frameworks */ = {isa = PBXBuildFile; productRef = 95555FB22960B7A2005BEF45 /* AckGen */; };
 		95555FB52960B7A2005BEF45 /* AckGenUI in Frameworks */ = {isa = PBXBuildFile; productRef = 95555FB42960B7A2005BEF45 /* AckGenUI */; };
 		95555FB72960B7F1005BEF45 /* Acknowledgements.plist in Resources */ = {isa = PBXBuildFile; fileRef = 95555FB62960B7F0005BEF45 /* Acknowledgements.plist */; };
@@ -330,6 +332,7 @@
 		954722F727A0093F00D1BA89 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		954722F827A0094000D1BA89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		954722FD27A0094000D1BA89 /* Fedigardens.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fedigardens.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusAttachmentAlternative.swift; sourceTree = "<group>"; };
 		95555FB62960B7F0005BEF45 /* Acknowledgements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Acknowledgements.plist; sourceTree = "<group>"; };
 		95555FB82960B8DA005BEF45 /* SettingsAcknowledgementList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAcknowledgementList.swift; sourceTree = "<group>"; };
 		95555FBA2960B9F7005BEF45 /* Acknowledgement+License.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Acknowledgement+License.swift"; sourceTree = "<group>"; };
@@ -635,6 +638,7 @@
 				956714132958B69D00BFF76A /* StatusDisclosedContent.swift */,
 				95CEFDE72959637400EEE96C /* StatusVerifiedButton.swift */,
 				95CEFDF1295A3B4900EEE96C /* StatusAuthorExtendedLabel.swift */,
+				954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */,
 			);
 			path = "Status Components";
 			sourceTree = "<group>";
@@ -1187,6 +1191,7 @@
 				953BC7C52957C73E005C7F2A /* StatusDetailViewModel.swift in Sources */,
 				95A1BF9829738A75002C88B6 /* ProfileSheetView.swift in Sources */,
 				9558C7F029579E66001B30C7 /* GardensComposeButton.swift in Sources */,
+				954C95052A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */,
 				95CD3C4F29650A600043CDB2 /* GardensViewModel.swift in Sources */,
 				952A06E129691B95008340A4 /* GardensAppCompactLayout.swift in Sources */,
 				95009EF2295E711100F32F85 /* AuthenticationViewModel.swift in Sources */,
@@ -1343,6 +1348,7 @@
 				957AF85029591B44000370E6 /* StatusPollView.swift in Sources */,
 				95CDCD232990297E002BD37A /* AttachmentViewerViewModel.swift in Sources */,
 				95801D60297CC13C00FE8D83 /* MessagingAuthorView.swift in Sources */,
+				954C95062A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */,
 				958C0C9927BE930D00ED6C23 /* Account+AccountName.swift in Sources */,
 				95CDCD252990297E002BD37A /* AttachmentViewer.swift in Sources */,
 				955F1B2929859E0600702BE8 /* SearchView.swift in Sources */,

--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -45,6 +45,10 @@
 		9547230A27A0094000D1BA89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 954722F827A0094000D1BA89 /* Assets.xcassets */; };
 		954C95052A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */; };
 		954C95062A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */; };
+		954C95092A04691E0019AE09 /* FrugalModeEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95082A04691E0019AE09 /* FrugalModeEnvironmentKey.swift */; };
+		954C950A2A04691E0019AE09 /* FrugalModeEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95082A04691E0019AE09 /* FrugalModeEnvironmentKey.swift */; };
+		954C950C2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */; };
+		954C950D2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */; };
 		95555FB32960B7A2005BEF45 /* AckGen in Frameworks */ = {isa = PBXBuildFile; productRef = 95555FB22960B7A2005BEF45 /* AckGen */; };
 		95555FB52960B7A2005BEF45 /* AckGenUI in Frameworks */ = {isa = PBXBuildFile; productRef = 95555FB42960B7A2005BEF45 /* AckGenUI */; };
 		95555FB72960B7F1005BEF45 /* Acknowledgements.plist in Resources */ = {isa = PBXBuildFile; fileRef = 95555FB62960B7F0005BEF45 /* Acknowledgements.plist */; };
@@ -333,6 +337,8 @@
 		954722F827A0094000D1BA89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		954722FD27A0094000D1BA89 /* Fedigardens.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fedigardens.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusAttachmentAlternative.swift; sourceTree = "<group>"; };
+		954C95082A04691E0019AE09 /* FrugalModeEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrugalModeEnvironmentKey.swift; sourceTree = "<group>"; };
+		954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NotificationCenter.swift"; sourceTree = "<group>"; };
 		95555FB62960B7F0005BEF45 /* Acknowledgements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Acknowledgements.plist; sourceTree = "<group>"; };
 		95555FB82960B8DA005BEF45 /* SettingsAcknowledgementList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAcknowledgementList.swift; sourceTree = "<group>"; };
 		95555FBA2960B9F7005BEF45 /* Acknowledgement+License.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Acknowledgement+License.swift"; sourceTree = "<group>"; };
@@ -533,6 +539,14 @@
 			);
 			name = Products;
 			path = ..;
+			sourceTree = "<group>";
+		};
+		954C95072A04690C0019AE09 /* Frugal Mode */ = {
+			isa = PBXGroup;
+			children = (
+				954C95082A04691E0019AE09 /* FrugalModeEnvironmentKey.swift */,
+			);
+			path = "Frugal Mode";
 			sourceTree = "<group>";
 		};
 		95555FC02960BDDD005BEF45 /* Licenses */ = {
@@ -764,6 +778,7 @@
 			isa = PBXGroup;
 			children = (
 				958C0C9A27BE955E00ED6C23 /* Composer */,
+				954C95072A04690C0019AE09 /* Frugal Mode */,
 				95CD3C4B296509260043CDB2 /* Intervention */,
 				95D28C73299024C50051D31E /* Media Viewer */,
 				952A010F27C67F1400F36B37 /* Messaging */,
@@ -899,6 +914,7 @@
 				953BC7CA2957EC27005C7F2A /* HashableType.swift */,
 				95CEFDEA295A031E00EEE96C /* Pip.swift */,
 				95555FBA2960B9F7005BEF45 /* Acknowledgement+License.swift */,
+				954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1183,6 +1199,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				954C95092A04691E0019AE09 /* FrugalModeEnvironmentKey.swift in Sources */,
 				95A36E93297CEDB900DA11D3 /* GardensAppCompactMorePage.swift in Sources */,
 				952A06E529692E95008340A4 /* UIDevice+Model.swift in Sources */,
 				955F1B3E2985DC1600702BE8 /* SearchTagView.swift in Sources */,
@@ -1246,6 +1263,7 @@
 				9547230627A0094000D1BA89 /* Gardens.swift in Sources */,
 				95A5C82B296A5CA00069F174 /* StatusQuickGlanceView.swift in Sources */,
 				955F1B5D2986FB0A00702BE8 /* SettingsVersionBlock.swift in Sources */,
+				954C950C2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */,
 				95555FBB2960B9F7005BEF45 /* Acknowledgement+License.swift in Sources */,
 				9537C6D9297DC71C0039F3C4 /* SettingsReadingPage.swift in Sources */,
 				9558C7EE29578B59001B30C7 /* AccountImage.swift in Sources */,
@@ -1343,6 +1361,7 @@
 				95801D5A297CC13400FE8D83 /* TimelineSplitView.swift in Sources */,
 				9537C6DD297DE7C50039F3C4 /* InterventionHandler.swift in Sources */,
 				953BC7CC2957EC27005C7F2A /* HashableType.swift in Sources */,
+				954C950A2A04691E0019AE09 /* FrugalModeEnvironmentKey.swift in Sources */,
 				95CEFDE92959637400EEE96C /* StatusVerifiedButton.swift in Sources */,
 				95801D59297CC13400FE8D83 /* StatusDetailProfileMenu.swift in Sources */,
 				957AF85029591B44000370E6 /* StatusPollView.swift in Sources */,
@@ -1413,6 +1432,7 @@
 				95801D57297CC13400FE8D83 /* StatusContextProvider.swift in Sources */,
 				95CDCD2C299066B5002BD37A /* GiantAlert.swift in Sources */,
 				95801D27297C752000FE8D83 /* Bundle+AppVersion.swift in Sources */,
+				954C950D2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */,
 				95801D3E297CC0B600FE8D83 /* SettingsInterventionPage.swift in Sources */,
 				9537C6E0297DED820039F3C4 /* InterventionAllowedMechanisms.swift in Sources */,
 				953BC7C02957B9E0005C7F2A /* Status+URIToUrl.swift in Sources */,

--- a/Fedigardens/Modules/Bootstrapping/Gardens.swift
+++ b/Fedigardens/Modules/Bootstrapping/Gardens.swift
@@ -30,6 +30,7 @@ struct Shout: App {
                 .environment(\.customEmojis, globalStore.emojis)
                 .environment(\.enforcedFrugalMode, globalStore.overrideFrugalMode)
                 .onOpenURL { url in
+                    globalStore.overrideFrugalModeFromLowPowerMode()
                     globalStore.checkAuthorizationToken(from: url)
                     if let newContext = globalStore.createInterventionContext(from: url) {
                         interventionHandler.assignNewContext(newContext)

--- a/Fedigardens/Modules/Bootstrapping/Gardens.swift
+++ b/Fedigardens/Modules/Bootstrapping/Gardens.swift
@@ -28,6 +28,7 @@ struct Shout: App {
                 .environment(\.interventionAuthorization, globalStore.interventionAuthorization ?? .default)
                 .environmentObject(interventionHandler)
                 .environment(\.customEmojis, globalStore.emojis)
+                .environment(\.enforcedFrugalMode, globalStore.overrideFrugalMode)
                 .onOpenURL { url in
                     globalStore.checkAuthorizationToken(from: url)
                     if let newContext = globalStore.createInterventionContext(from: url) {
@@ -40,6 +41,9 @@ struct Shout: App {
                         await globalStore.getUserProfile()
                         await globalStore.getInstanceEmojis()
                     }
+                }
+                .onReceive(of: Notification.Name.NSProcessInfoPowerStateDidChange) { _ in
+                    globalStore.overrideFrugalModeFromLowPowerMode()
                 }
         }
 

--- a/Fedigardens/Modules/Bootstrapping/GardensViewModel.swift
+++ b/Fedigardens/Modules/Bootstrapping/GardensViewModel.swift
@@ -22,6 +22,7 @@ class GardensViewModel: ObservableObject {
     @Published var userProfile: Account?
     @Published var interventionAuthorization: InterventionAuthorizationContext?
     @Published var emojis: [RemoteEmoji] = []
+    @Published var overrideFrugalMode = false
 
     func checkAuthorizationToken(from url: URL) {
         guard url.absoluteString.contains("gardens://oauth") else { return }
@@ -65,5 +66,9 @@ class GardensViewModel: ObservableObject {
         case .failure(let error):
             print("Failed to fetch emojis: \(error.localizedDescription)")
         }
+    }
+
+    func overrideFrugalModeFromLowPowerMode() {
+        overrideFrugalMode = ProcessInfo.processInfo.isLowPowerModeEnabled
     }
 }

--- a/Fedigardens/Modules/Components/AccountImage.swift
+++ b/Fedigardens/Modules/Components/AccountImage.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
 struct AccountImage: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
 
     enum ProfileImageSize: CGFloat {
         case small = 20
@@ -41,7 +42,7 @@ struct AccountImage: View {
 
     var body: some View {
         Group {
-            if frugalMode {
+            if enforcedFrugalMode || frugalMode {
                 Image(systemName: "person.circle")
                     .resizable()
                     .scaledToFit()

--- a/Fedigardens/Modules/Components/Profiles/Components/ProfileSheetFields.swift
+++ b/Fedigardens/Modules/Components/Profiles/Components/ProfileSheetFields.swift
@@ -17,11 +17,12 @@ import Alice
 import EmojiText
 
 struct ProfileSheetFields: View {
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @AppStorage(.frugalMode) var frugalMode: Bool = false
     var profile: Account
 
     private var emojis: [RemoteEmoji] {
-        return frugalMode ? [] : profile.emojis.map(\.remoteEmoji)
+        return (enforcedFrugalMode || frugalMode) ? [] : profile.emojis.map(\.remoteEmoji)
     }
 
     var body: some View {

--- a/Fedigardens/Modules/Components/Profiles/Components/ProfileSheetHeaderView.swift
+++ b/Fedigardens/Modules/Components/Profiles/Components/ProfileSheetHeaderView.swift
@@ -20,10 +20,11 @@ struct ProfileSheetHeaderView: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
     @EnvironmentObject var viewModel: ProfileSheetViewModel
     @Environment(\.customEmojis) var emojis
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     var profile: Account
 
     private var allEmojis: [RemoteEmoji] {
-        if frugalMode { return [] }
+        if enforcedFrugalMode || frugalMode { return [] }
         return emojis + profile.emojis.map(\.remoteEmoji)
     }
 

--- a/Fedigardens/Modules/Components/Profiles/Components/ProfileSheetLabel.swift
+++ b/Fedigardens/Modules/Components/Profiles/Components/ProfileSheetLabel.swift
@@ -17,11 +17,12 @@ import Alice
 import EmojiText
 
 struct ProfileSheetLabel: View {
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @AppStorage(.frugalMode) var frugalMode: Bool = false
     var profile: Account
 
     private var emojis: [RemoteEmoji] {
-        return frugalMode ? [] : profile.emojis.map(\.remoteEmoji)
+        return (enforcedFrugalMode || frugalMode) ? [] : profile.emojis.map(\.remoteEmoji)
     }
 
     var body: some View {

--- a/Fedigardens/Modules/Components/Profiles/ProfileSheetView.swift
+++ b/Fedigardens/Modules/Components/Profiles/ProfileSheetView.swift
@@ -20,11 +20,12 @@ struct ProfileSheetView: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
     @Environment(\.customEmojis) var emojis
     @Environment(\.dismiss) var dismiss
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @StateObject private var viewModel = ProfileSheetViewModel()
     var profile: Account
 
     private var allEmojis: [RemoteEmoji] {
-        if frugalMode { return [] }
+        if enforcedFrugalMode || frugalMode { return [] }
         return emojis + profile.emojis.map { emoji in emoji.remote() }
     }
 

--- a/Fedigardens/Modules/Components/Statuses/Status Components/StatusAttachmentAlternative.swift
+++ b/Fedigardens/Modules/Components/Statuses/Status Components/StatusAttachmentAlternative.swift
@@ -1,0 +1,45 @@
+//
+//  StatusAttachmentAlternative.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 5/4/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+import Alice
+
+struct StatusAttachmentAlernative: View {
+    var attachment: MediaAttachment
+    var body: some View {
+        Label(attachment.description ?? "attachments.description.missing".localized(), systemImage: symbol)
+    }
+
+    var symbol: String {
+        switch attachment.type {
+        case .audio:
+            return "speaker.wave.2.fill"
+        case .gifv, .video:
+            return "film"
+        case .image:
+            return "photo"
+        case .unknown:
+            return "questionmark.app.dashed"
+        }
+    }
+}
+
+struct StatusAttachmentAlernative_Previews: PreviewProvider {
+    static let attachments: [MediaAttachment] = MockData.status!.mediaAttachments
+    static var previews: some View {
+        ForEach(attachments) { attachment in
+            StatusAttachmentAlernative(attachment: attachment)
+        }
+    }
+}

--- a/Fedigardens/Modules/Components/Statuses/Status Components/StatusAuthorExtendedLabel.swift
+++ b/Fedigardens/Modules/Components/Statuses/Status Components/StatusAuthorExtendedLabel.swift
@@ -19,6 +19,7 @@ import EmojiText
 struct StatusAuthorExtendedLabel: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
     @Environment(\.customEmojis) var emojis
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
 
     enum VerificationPlacementPolicy {
         case byAuthorName
@@ -50,7 +51,7 @@ struct StatusAuthorExtendedLabel: View {
     }
 
     private var allEmojis: [RemoteEmoji] {
-        if frugalMode { return [] }
+        if enforcedFrugalMode || frugalMode { return [] }
         let emojisFromStatus = status.account.emojis + (status.reblog?.account.emojis ?? [])
         return emojis + emojisFromStatus.map { emoji in emoji.remote() }
     }

--- a/Fedigardens/Modules/Components/Statuses/Status Components/StatusDisclosedContent.swift
+++ b/Fedigardens/Modules/Components/Statuses/Status Components/StatusDisclosedContent.swift
@@ -19,6 +19,7 @@ import EmojiText
 struct StatusDisclosedContent: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
     @Environment(\.customEmojis) var emojis
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     var discloseContent: Bool
 
     var status: Status
@@ -35,7 +36,7 @@ struct StatusDisclosedContent: View {
     }
 
     private var allEmojis: [RemoteEmoji] {
-        if frugalMode { return [] }
+        if enforcedFrugalMode || frugalMode { return [] }
         let emojisFromStatus = status.account.emojis + (status.reblog?.account.emojis ?? [])
         return emojis + emojisFromStatus.map(\.remoteEmoji)
     }
@@ -53,7 +54,7 @@ struct StatusDisclosedContent: View {
             }
             if truncateLines == nil {
                 if status.mediaAttachments.isNotEmpty {
-                    if frugalMode {
+                    if enforcedFrugalMode || frugalMode {
                         InformationCard(
                             title: "general.frugalon".localized(),
                             systemImage: "leaf",

--- a/Fedigardens/Modules/Components/Statuses/Status Components/StatusDisclosedContent.swift
+++ b/Fedigardens/Modules/Components/Statuses/Status Components/StatusDisclosedContent.swift
@@ -52,15 +52,23 @@ struct StatusDisclosedContent: View {
                     .textSelection(.enabled)
             }
             if truncateLines == nil {
-                if frugalMode {
-                    InformationCard(
-                        title: "general.frugalon".localized(),
-                        systemImage: "leaf",
-                        content: "status.media.frugalon".localized()
-                    )
-                    .tint(.green)
-                } else {
-                    AttachmentMediaGroup(status: status)
+                if status.mediaAttachments.isNotEmpty {
+                    if frugalMode {
+                        InformationCard(
+                            title: "general.frugalon".localized(),
+                            systemImage: "leaf",
+                            content: "status.media.frugalon".localized()
+                        )
+                        .tint(.green)
+                        VStack(alignment: .leading) {
+                            ForEach(status.mediaAttachments) { attachment in
+                                StatusAttachmentAlernative(attachment: attachment)
+                            }
+                        }
+                        .multilineTextAlignment(.leading)
+                    } else {
+                        AttachmentMediaGroup(status: status)
+                    }
                 }
                 if let poll = status.poll {
                     if poll.expired || poll.voted == true {

--- a/Fedigardens/Modules/Components/Statuses/StatusView.swift
+++ b/Fedigardens/Modules/Components/Statuses/StatusView.swift
@@ -38,6 +38,7 @@ struct StatusView: View {
     }
 
     @Environment(\.customEmojis) var emojis
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @AppStorage("status.show-statistics") var showsStatistics: Bool = true
     @AppStorage(.alwaysShowUserHandle) var showsUserHandle: Bool = true
     @AppStorage(.frugalMode) var frugalMode: Bool = false
@@ -54,7 +55,7 @@ struct StatusView: View {
     fileprivate var displayDisclosedContent: Bool
 
     private var allEmojis: [RemoteEmoji] {
-        if frugalMode { return [] }
+        if enforcedFrugalMode || frugalMode { return [] }
         let emojisFromStatus = status.account.emojis + (status.reblog?.account.emojis ?? [])
         return emojis + emojisFromStatus.map { emoji in emoji.remote() }
     }
@@ -94,17 +95,18 @@ struct StatusView: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            if profileImagePlacement == .byEntireView, !frugalMode {
+            if profileImagePlacement == .byEntireView, !(enforcedFrugalMode || frugalMode) {
                 authorImage
             }
             VStack(alignment: .leading, spacing: truncateLines != nil ? 4 : 8) {
-                if reblogNoticePlacement == .aboveOriginalAuthor, status.reblog != nil, !frugalMode {
+                if reblogNoticePlacement == .aboveOriginalAuthor, status.reblog != nil,
+                   !(enforcedFrugalMode || frugalMode) {
                     reblogNotice
                         .font(.subheadline)
                         .padding(.vertical, 8)
                 }
                 HStack {
-                    if profileImagePlacement == .byAuthorName, !frugalMode { authorImage }
+                    if profileImagePlacement == .byAuthorName, !(enforcedFrugalMode || frugalMode) { authorImage }
                     VStack(alignment: .leading) {
                         HStack(alignment: .top) {
                             StatusAuthorExtendedLabel(

--- a/Fedigardens/Modules/Features/Frugal Mode/FrugalModeEnvironmentKey.swift
+++ b/Fedigardens/Modules/Features/Frugal Mode/FrugalModeEnvironmentKey.swift
@@ -4,5 +4,23 @@
 //
 //  Created by Marquis Kurt on 5/4/23.
 //
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
 
-import Foundation
+import SwiftUI
+
+private struct FrugalModeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var enforcedFrugalMode: Bool {
+        get { return self[FrugalModeEnvironmentKey.self] }
+        set { self[FrugalModeEnvironmentKey.self] = newValue }
+    }
+}

--- a/Fedigardens/Modules/Features/Frugal Mode/FrugalModeEnvironmentKey.swift
+++ b/Fedigardens/Modules/Features/Frugal Mode/FrugalModeEnvironmentKey.swift
@@ -1,0 +1,8 @@
+//
+//  FrugalModeEnvironmentKey.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 5/4/23.
+//
+
+import Foundation

--- a/Fedigardens/Modules/Features/Polling/PollCallToActionView.swift
+++ b/Fedigardens/Modules/Features/Polling/PollCallToActionView.swift
@@ -18,6 +18,7 @@ import Alice
 
 struct PollCallToActionView: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
 
     var author: Account
     var poll: Poll
@@ -30,7 +31,7 @@ struct PollCallToActionView: View {
     }
 
     private var emojis: [RemoteEmoji] {
-        return frugalMode ? [] : author.emojis.map(\.remoteEmoji)
+        return (enforcedFrugalMode || frugalMode) ? [] : author.emojis.map(\.remoteEmoji)
     }
 
     var body: some View {

--- a/Fedigardens/Modules/Features/Search/Pages/SearchDirectoryView.swift
+++ b/Fedigardens/Modules/Features/Search/Pages/SearchDirectoryView.swift
@@ -18,6 +18,7 @@ import EmojiText
 
 struct SearchDirectoryView: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     var directory: [Account]
     @StateObject var viewModel: SearchViewModel
 
@@ -33,7 +34,7 @@ struct SearchDirectoryView: View {
                                 .profileSize(.xlarge)
                             EmojiText(
                                 markdown: account.getAccountName(),
-                                emojis: frugalMode ? [] : account.emojis.map(\.remoteEmoji)
+                                emojis: (enforcedFrugalMode || frugalMode) ? [] : account.emojis.map(\.remoteEmoji)
                             )
                             .font(.headline)
                             Text("@\(account.acct)")

--- a/Fedigardens/Modules/Features/Search/SearchAccountView.swift
+++ b/Fedigardens/Modules/Features/Search/SearchAccountView.swift
@@ -18,10 +18,11 @@ import EmojiText
 
 struct SearchAccountView: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     var account: Account
 
     private var emojis: [RemoteEmoji] {
-        return frugalMode ? [] : account.emojis.map(\.remoteEmoji)
+        return (enforcedFrugalMode || frugalMode) ? [] : account.emojis.map(\.remoteEmoji)
     }
 
     var body: some View {

--- a/Fedigardens/Modules/Layout/Status Detail View/Components/StatusDetailQuote.swift
+++ b/Fedigardens/Modules/Layout/Status Detail View/Components/StatusDetailQuote.swift
@@ -18,6 +18,7 @@ import EmojiText
 
 struct StatusDetailQuote: View {
     @AppStorage(.frugalMode) var frugalMode: Bool = false
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @State private var expandQuote = false
     @Binding var displayUndisclosedContent: Bool
     var status: Status
@@ -25,7 +26,7 @@ struct StatusDetailQuote: View {
     var source: Status.QuoteSource
 
     private var emojis: [RemoteEmoji] {
-        if frugalMode { return [] }
+        if enforcedFrugalMode || frugalMode { return [] }
         return status.emojis.map(\.remoteEmoji) + status.account.emojis.map(\.remoteEmoji)
     }
 

--- a/Fedigardens/Modules/Layout/Status Detail View/Components/StatusDetailToolbar.swift
+++ b/Fedigardens/Modules/Layout/Status Detail View/Components/StatusDetailToolbar.swift
@@ -17,6 +17,7 @@ import Alice
 
 struct StatusDetailToolbar: CustomizableToolbarContent {
     @Environment(\.deviceModel) var deviceModel
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @Environment(\.openURL) var openURL
     @Environment(\.openWindow) var openWindow
     @Environment(\.userProfile) var currentUser
@@ -156,7 +157,7 @@ struct StatusDetailToolbar: CustomizableToolbarContent {
                     } label: {
                         Label("status.attachmentaction", systemImage: "paperclip")
                     }
-                    .disabled(frugalMode || allAttached == nil || allAttached?.isEmpty == true)
+                    .disabled(enforcedFrugalMode || frugalMode || allAttached == nil || allAttached?.isEmpty == true)
                 }
             }
             .defaultCustomization(options: .alwaysAvailable)

--- a/Fedigardens/Modules/Layout/Status Navigation List/StatusNavigationList.swift
+++ b/Fedigardens/Modules/Layout/Status Navigation List/StatusNavigationList.swift
@@ -19,6 +19,7 @@ import SwiftUI
 // MARK: - Status Navigation List
 struct StatusNavigationList<Extras: View>: View {
     typealias ViewModel = StatusNavigationListViewModel
+    @Environment(\.enforcedFrugalMode) private var enforcedFrugalMode
     @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
     @Environment(\.openWindow) private var openWindow
     @AppStorage(.useFocusedInbox) private var useFocusedInbox: Bool = false
@@ -42,7 +43,7 @@ struct StatusNavigationList<Extras: View>: View {
                     .pickerStyle(.segmented)
                     .listRowSeparator(.hidden)
                 }
-                if frugalMode {
+                if enforcedFrugalMode || frugalMode {
                     Label("general.frugalon", systemImage: "leaf.fill")
                         .bold()
                         .font(.system(.subheadline, design: .rounded))

--- a/Fedigardens/Modules/Settings/Pages/SettingsEnergyPage.swift
+++ b/Fedigardens/Modules/Settings/Pages/SettingsEnergyPage.swift
@@ -15,6 +15,7 @@
 import SwiftUI
 
 struct SettingsEnergyPage: View {
+    @Environment(\.enforcedFrugalMode) var enforcedFrugalMode
     @AppStorage(.loadLimit) var loadLimit: Int = 10
     @AppStorage(.frugalMode) private var frugalMode: Bool = false
 
@@ -37,6 +38,7 @@ struct SettingsEnergyPage: View {
                 Toggle(isOn: $frugalMode) {
                     Text("settings.frugalmode.title")
                 }
+                .disabled(enforcedFrugalMode)
             } footer: {
                 Text("settings.frugalmode.detail")
             }

--- a/Fedigardens/Modules/Utilities/Mock/MockData.swift
+++ b/Fedigardens/Modules/Utilities/Mock/MockData.swift
@@ -38,3 +38,5 @@ struct MockData {
 
     static let poll: Poll? = try! JSONDecoder.decodeFromResource(from: "Poll")
 }
+
+// swiftlint:enable force_try

--- a/Fedigardens/Modules/Utilities/View+NotificationCenter.swift
+++ b/Fedigardens/Modules/Utilities/View+NotificationCenter.swift
@@ -1,0 +1,26 @@
+//
+//  View+NotificationCenter.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 5/4/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+
+extension View {
+    func onReceive(
+        of name: Notification.Name,
+        from center: NotificationCenter = .default,
+        in object: AnyObject? = nil,
+        perform action: @escaping (Notification) -> Void
+    ) -> some View {
+        self.onReceive(center.publisher(for: name, object: object), perform: action)
+    }
+}

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "status.languagecode" = "Select a Language";
 "status.editmode.title" = "You are editing this discussion.";
 "status.editmode.detail" = "Some composition features such as setting the visibility may not be available.";
-"status.media.frugalon" = "Media attachments won't be displayed to help use less resources and curb carbon emissions.";
+"status.media.frugalon" = "Media attachments won't be displayed to help use less resources and curb carbon emissions. Below are alternate descriptions provided by the author.";
 
 // MARK: - Status: Polls -
 "status.poll.voted" = "You have contributed to this poll already.";

--- a/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Fedigardens/Resources/Localizations/en.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "status.languagecode" = "Select a Language";
 "status.editmode.title" = "You are editing this discussion.";
 "status.editmode.detail" = "Some composition features such as setting the visibility may not be available.";
-"status.media.frugalon" = "Media attachments won't be displayed to help use less resources and curb carbon emissions. Below are alternate descriptions provided by the author.";
+"status.media.frugalon" = "Alternate descriptions of media are displayed instead to help use less resources and curb carbon emissions.";
 
 // MARK: - Status: Polls -
 "status.poll.voted" = "You have contributed to this poll already.";
@@ -284,7 +284,7 @@
 // MARK: - Settings: Energy Savings -
 "settings.section.energy" = "Energy Savings";
 "settings.frugalmode.title" = "Frugal Mode";
-"settings.frugalmode.detail" = "Using frugal mode can help use less resources and curb carbon emissions by limiting the content being loaded. [Learn more…](https://fedigardens.app/support/#frugal-mode)";
+"settings.frugalmode.detail" = "Using frugal mode can help use less resources and curb carbon emissions by limiting the content being loaded. Frugal Mode will be enabled automatically when Low Power Mode is on. [Learn more…](https://fedigardens.app/support/#frugal-mode)";
 
 // MARK: - Acknowledgements
 "acknowledge.title" = "Acknowledgements";


### PR DESCRIPTION
This PR introduces new improvements to Frugal Mode:

- Instead of showing nothing for media attachments, alternate descriptions are displayed. This should allow users to still understand discussions that have media attachments in them, and it strongly encourages use of alternate descriptions.
- When iOS's Low Power Mode is turned on, Frugal Mode will automatically turn on, regardless of user preference, to limit resources.