### PR TITLE
[GardenGate] Refactor authentication view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ If you need to list changes to this changelog but there isn't an entry for it, c
 And list your changes under that.
 -->
 
+## [Unreleased] - Date Pending
+
+- Disables predictive text on the authentication screen.
+- Updates the authentication, frugal mode, and interventions modules with FlowKit.
+- Adds a clear button and "Done" accessory to the authentication text field.
+- Autohides the Fedigardens logo when actively editing text in the authentication screen.
+
 ## [1.0-40 (beta)] - 8/5/23
 - (FGD-43) Adds a new setting "Prefer Matrix Conversations" which will start Matrix conversations with fediverse people
   that have the "Matrix: (Matrix ID)" field in their bio with a valid Matrix ID. This setting applies in profile pages

--- a/Packages/GardenGate/Sources/GardenGate/AuthenticationGateHeaderView.swift
+++ b/Packages/GardenGate/Sources/GardenGate/AuthenticationGateHeaderView.swift
@@ -1,0 +1,50 @@
+//
+//  AuthenticationGateHeaderView.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 1/7/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+
+struct AuthenticationGateHeaderView: View {
+    var compact: Bool
+    var alignment: HorizontalAlignment = .center
+
+    var body: some View {
+        VStack(alignment: alignment) {
+            if !compact {
+                Image("GardensIcon")
+                    .symbolRenderingMode(.palette)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 76, height: 76)
+                    .cornerRadius(16)
+            }
+            Text("auth.welcome", bundle: .module)
+                .font(.system(.title2, design: .rounded))
+                .bold()
+            Text("auth.appname", bundle: .module)
+                .font(.system(size: 56, weight: .bold, design: .rounded))
+                .foregroundColor(.accentColor)
+        }
+        .animation(.bouncy, value: compact)
+    }
+}
+
+struct AuthenticationGateHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            AuthenticationGateHeaderView(compact: true, alignment: .leading)
+            AuthenticationGateHeaderView(compact: true, alignment: .center)
+            AuthenticationGateHeaderView(compact: false, alignment: .leading)
+        }
+    }
+}

--- a/Packages/GardenGate/Sources/GardenGate/AuthenticationGateTextField.swift
+++ b/Packages/GardenGate/Sources/GardenGate/AuthenticationGateTextField.swift
@@ -1,0 +1,106 @@
+//
+//  AuthenticationGateTextField.swift
+//  Fedigardens
+//
+//  Created by Marquis Kurt on 1/7/23.
+//
+//  This file is part of Fedigardens.
+//
+//  Fedigardens is non-violent software: you can use, redistribute, and/or modify it under the terms of the CNPLv7+
+//  as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
+//
+//  Fedigardens comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. See the CNPL for
+//  details.
+
+import SwiftUI
+
+struct AuthenticationGateTextField: View {
+    var focusedDomainEntry: FocusState<Bool>.Binding
+    var onTextChange: (String) -> Void
+    @State private var domainName = ""
+
+    init(focusedDomainEntry: FocusState<Bool>.Binding,
+         onTextChange: @escaping (String) -> Void,
+         domainName: String = "") {
+        self.focusedDomainEntry = focusedDomainEntry
+        self.onTextChange = onTextChange
+        self.domainName = domainName
+    }
+
+    var body: some View {
+        HStack {
+            Text("https://")
+                .foregroundColor(.secondary)
+            TextField("mastodon.example", text: $domainName)
+                .keyboardType(.URL)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .focused(focusedDomainEntry)
+                .toolbar { keyboardToolbar }
+                .onChange(of: domainName) { value in
+                    onTextChange(value)
+                }
+            if !domainName.isEmpty {
+                Button {
+                    withAnimation {
+                        domainName = ""
+                    }
+                } label: {
+                    Label {
+                        Text("auth.textfield.clear", bundle: .module)
+                    } icon: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                    .labelStyle(.iconOnly)
+                }
+                .animation(.easeInOut, value: domainName.isEmpty)
+            }
+
+        }
+        .padding(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.secondary.opacity(0.5))
+        )
+    }
+
+    var keyboardToolbar: some ToolbarContent {
+        Group {
+            ToolbarItem(id: "auth.spacer", placement: .keyboard) {
+                Spacer()
+            }
+            ToolbarItem(id: "auth.keyboard.done", placement: .keyboard) {
+                Button {
+                    focusedDomainEntry.wrappedValue.toggle()
+                } label: {
+                    Text("auth.keyboard.done", bundle: .module)
+                }
+                .font(.system(.body, design: .rounded))
+                .bold()
+                .buttonStyle(.borderless)
+            }
+        }
+    }
+}
+
+private struct AuthenticationGateTextFieldPreviewer: View {
+    @FocusState private var focused: Bool
+    @State private var current = ""
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Current text: \(current)")
+            AuthenticationGateTextField(focusedDomainEntry: $focused) { value in
+                current = value
+            }
+        }
+        .padding()
+    }
+}
+
+struct AuthenticationGateTextField_Previews: PreviewProvider {
+    static var previews: some View {
+        AuthenticationGateTextFieldPreviewer()
+    }
+}

--- a/Packages/GardenGate/Sources/GardenGate/AuthenticationGateView.swift
+++ b/Packages/GardenGate/Sources/GardenGate/AuthenticationGateView.swift
@@ -96,6 +96,7 @@ public struct AuthenticationGateView: StatefulView {
                     Text("https://")
                         .foregroundColor(.secondary)
                     TextField("mastodon.example", text: $domainName)
+                        .keyboardType(.URL)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
                         .onChange(of: domainName, perform: { value in

--- a/Packages/GardenGate/Sources/GardenGate/Resources/en.lproj/Localizable.strings
+++ b/Packages/GardenGate/Sources/GardenGate/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
   Created by Marquis Kurt on 6/24/23.
   
 */
+
 "auth.appname" = "Fedigardens";
 "auth.learnmore" = "Learn More…";
 "auth.welcome" = "Welcome to";
@@ -17,3 +18,5 @@
 "auth.disallowed.message" = "Fedigardens cannot sign in to %@ because the developers cannot verify that this server moderates the content posted by its users.";
 "auth.badurl.message" = "The community server '%@' likely contains invalid URL characters. If the domain you provided contains legal characters, you can file a report on Raceway to help us diagnose the issue.";
 "auth.badurl.racewaycta" = "Report on Raceway…";
+"auth.keyboard.done" = "Done";
+"auth.textfield.clear" = "Clear";


### PR DESCRIPTION
The authentication view in GardenGate has been refactored to make developing on the view easier. This includes separating the text field and header views from the main authentication view.

This also disables predictive text and sets the keyboard type to URL, resolving an issue pertaining to autocompletion.

Finally, the text field in the authentication view gains a clear button per HIG and also presents a "Done" button in its input accessory view to dismiss the keyboard automatically.

**Demo**

https://github.com/alicerunsonfedora/fedigardens/assets/13445064/722cbd5b-dc8e-4031-9d90-901684ef1691

