### PR TITLE
FlowKit: Migration to Actors

### DIFF
--- a/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
+++ b/Fedigardens/Fedigardens.xcodeproj/project.pbxproj
@@ -41,8 +41,8 @@
 		9547230A27A0094000D1BA89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 954722F827A0094000D1BA89 /* Assets.xcassets */; };
 		954C95052A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */; };
 		954C95062A0461310019AE09 /* StatusAttachmentAlternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */; };
-		954C950C2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */; };
-		954C950D2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */; };
+		954C950C2A046AA20019AE09 /* View+ExtraModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C950B2A046AA20019AE09 /* View+ExtraModifiers.swift */; };
+		954C950D2A046AA20019AE09 /* View+ExtraModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C950B2A046AA20019AE09 /* View+ExtraModifiers.swift */; };
 		954C95162A05E67F0019AE09 /* Runestone in Frameworks */ = {isa = PBXBuildFile; productRef = 954C95152A05E67F0019AE09 /* Runestone */; };
 		954C95192A05E6A50019AE09 /* RunestoneViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95182A05E6A50019AE09 /* RunestoneViewer.swift */; };
 		954C951A2A05E6A50019AE09 /* RunestoneViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C95182A05E6A50019AE09 /* RunestoneViewer.swift */; };
@@ -329,7 +329,7 @@
 		954722F827A0094000D1BA89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		954722FD27A0094000D1BA89 /* Fedigardens.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fedigardens.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		954C95042A0461310019AE09 /* StatusAttachmentAlternative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusAttachmentAlternative.swift; sourceTree = "<group>"; };
-		954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NotificationCenter.swift"; sourceTree = "<group>"; };
+		954C950B2A046AA20019AE09 /* View+ExtraModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ExtraModifiers.swift"; sourceTree = "<group>"; };
 		954C95182A05E6A50019AE09 /* RunestoneViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunestoneViewer.swift; sourceTree = "<group>"; };
 		95555FB62960B7F0005BEF45 /* Acknowledgements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Acknowledgements.plist; sourceTree = "<group>"; };
 		95555FB82960B8DA005BEF45 /* SettingsAcknowledgementList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAcknowledgementList.swift; sourceTree = "<group>"; };
@@ -682,10 +682,11 @@
 				959349F1295A94ED0073D000 /* Alice */,
 				953DE4D227D69C7D0043A357 /* Bundle+AppVersion.swift */,
 				95ADAE1127B6CDC50011FD83 /* DateFormatter+Mastodon.swift */,
+				95801D2D297C852100FE8D83 /* NSTextCheckingResult+Substring.swift */,
 				95ADADE327B6A6BB0011FD83 /* String+AttributedContent.swift */,
 				952A06E429692E95008340A4 /* UIDevice+Model.swift */,
 				95B368A02965106C00336284 /* URL+CustomInits.swift */,
-				95801D2D297C852100FE8D83 /* NSTextCheckingResult+Substring.swift */,
+				954C950B2A046AA20019AE09 /* View+ExtraModifiers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -896,7 +897,6 @@
 				953BC7CA2957EC27005C7F2A /* HashableType.swift */,
 				95CEFDEA295A031E00EEE96C /* Pip.swift */,
 				95555FBA2960B9F7005BEF45 /* Acknowledgement+License.swift */,
-				954C950B2A046AA20019AE09 /* View+NotificationCenter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1241,7 +1241,7 @@
 				9547230627A0094000D1BA89 /* Gardens.swift in Sources */,
 				95A5C82B296A5CA00069F174 /* StatusQuickGlanceView.swift in Sources */,
 				955F1B5D2986FB0A00702BE8 /* SettingsVersionBlock.swift in Sources */,
-				954C950C2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */,
+				954C950C2A046AA20019AE09 /* View+ExtraModifiers.swift in Sources */,
 				95555FBB2960B9F7005BEF45 /* Acknowledgement+License.swift in Sources */,
 				9537C6D9297DC71C0039F3C4 /* SettingsReadingPage.swift in Sources */,
 				9558C7EE29578B59001B30C7 /* AccountImage.swift in Sources */,
@@ -1404,7 +1404,7 @@
 				95801D57297CC13400FE8D83 /* StatusContextProvider.swift in Sources */,
 				95CDCD2C299066B5002BD37A /* GiantAlert.swift in Sources */,
 				95801D27297C752000FE8D83 /* Bundle+AppVersion.swift in Sources */,
-				954C950D2A046AA20019AE09 /* View+NotificationCenter.swift in Sources */,
+				954C950D2A046AA20019AE09 /* View+ExtraModifiers.swift in Sources */,
 				95801D3E297CC0B600FE8D83 /* SettingsInterventionPage.swift in Sources */,
 				9537C6E0297DED820039F3C4 /* InterventionAllowedMechanisms+UserDefaults.swift in Sources */,
 				953BC7C02957B9E0005C7F2A /* Status+URIToUrl.swift in Sources */,

--- a/Fedigardens/Modules/Bootstrapping/GardensViewModel.swift
+++ b/Fedigardens/Modules/Bootstrapping/GardensViewModel.swift
@@ -20,6 +20,8 @@ import Foundation
 import Interventions
 
 class GardensViewModel: ObservableObject {
+    @Published var currentInterventionAuthContext = InterventionAuthorizationContext.default
+    @Published var overrideFrugalMode: Bool = false
     @Published var userProfile: Account?
     @Published var interventionAuthorization: InterventionAuthorizationContext?
     @Published var emojis: [RemoteEmoji] = []
@@ -38,7 +40,6 @@ class GardensViewModel: ObservableObject {
         }
         let allowedTimeInterval = TimeInterval(parameters["allowedTimeInterval"] ?? "0") ?? 0
         let allowedFetchSize = Int(parameters["allowedPostsCount"] ?? "10") ?? 10
-        interventionAuthorization = .init(allowedTimeInterval: allowedTimeInterval, allowedFetchSize: allowedFetchSize)
         return interventionAuthorization
     }
 

--- a/Fedigardens/Modules/Bootstrapping/GardensViewModel.swift
+++ b/Fedigardens/Modules/Bootstrapping/GardensViewModel.swift
@@ -23,7 +23,6 @@ class GardensViewModel: ObservableObject {
     @Published var currentInterventionAuthContext = InterventionAuthorizationContext.default
     @Published var overrideFrugalMode: Bool = false
     @Published var userProfile: Account?
-    @Published var interventionAuthorization: InterventionAuthorizationContext?
     @Published var emojis: [RemoteEmoji] = []
 
     func checkAuthorizationToken(from url: URL) {
@@ -35,12 +34,12 @@ class GardensViewModel: ObservableObject {
 
     func createInterventionContext(from url: URL) -> InterventionAuthorizationContext? {
         guard let parameters = url.queryParameters else {
-            interventionAuthorization = nil
             return nil
         }
         let allowedTimeInterval = TimeInterval(parameters["allowedTimeInterval"] ?? "0") ?? 0
         let allowedFetchSize = Int(parameters["allowedPostsCount"] ?? "10") ?? 10
-        return interventionAuthorization
+        return InterventionAuthorizationContext(allowedTimeInterval: allowedTimeInterval,
+                                                allowedFetchSize: allowedFetchSize)
     }
 
     func getUserProfile() async {

--- a/Fedigardens/Modules/Utilities/Extensions/View+ExtraModifiers.swift
+++ b/Fedigardens/Modules/Utilities/Extensions/View+ExtraModifiers.swift
@@ -1,5 +1,5 @@
 //
-//  View+NotificationCenter.swift
+//  View+ExtraModifiers.swift
 //  Fedigardens
 //
 //  Created by Marquis Kurt on 5/4/23.
@@ -15,12 +15,18 @@
 import SwiftUI
 
 extension View {
-    func onReceive(
-        of name: Notification.Name,
-        from center: NotificationCenter = .default,
-        in object: AnyObject? = nil,
-        perform action: @escaping (Notification) -> Void
-    ) -> some View {
+    func onReceive(of name: Notification.Name,
+                   from center: NotificationCenter = .default,
+                   in object: AnyObject? = nil,
+                   perform action: @escaping (Notification) -> Void) -> some View {
         onReceive(center.publisher(for: name, object: object), perform: action)
+    }
+
+    func onOpenURL(perform task: @escaping (URL) async -> Void) -> some View {
+        self.onOpenURL(perform: { url in
+            Task {
+                await task(url)
+            }
+        })
     }
 }

--- a/Packages/FlowKit/Sources/FlowKit/StatefulFlowProviding.swift
+++ b/Packages/FlowKit/Sources/FlowKit/StatefulFlowProviding.swift
@@ -15,7 +15,7 @@
 /// A protocol that provides a stateful flow.
 ///
 /// This is the basis for most view models that follow this approach.
-public protocol StatefulFlowProviding: AnyObject {
+public protocol StatefulFlowProviding: Actor {
     /// The possible states that the flow can encounter.
     ///
     /// This is typically defined as an enum with multiple cases:

--- a/Packages/FlowKit/Sources/FlowKit/StatefulFlowProviding.swift
+++ b/Packages/FlowKit/Sources/FlowKit/StatefulFlowProviding.swift
@@ -44,7 +44,7 @@ public protocol StatefulFlowProviding: Actor {
     /// A handler that executes whenever the ``state-swift.property`` is changed.
     ///
     /// - Important: This should never be directly set, but it should be subscribed to using ``subscribe(perform:)``.
-    var onStateChange: ((State) -> Void)? { get set }
+    var stateSubscribers: [((State) -> Void)] { get set }
 
     /// Emits an event asynchronously.
     ///
@@ -81,6 +81,6 @@ extension StatefulFlowProviding {
     ///
     /// - Parameter handler: The closure that will be executed whenever ``state-swift.property`` changes.
     public func subscribe(perform handler: @escaping (State) -> Void) {
-        self.onStateChange = handler
+        self.stateSubscribers.append(handler)
     }
 }

--- a/Packages/FlowKit/Sources/FlowKit/StatefulView.swift
+++ b/Packages/FlowKit/Sources/FlowKit/StatefulView.swift
@@ -59,7 +59,9 @@ extension View where Self: StatefulView {
     public var body: some View {
         statefulBody
             .onAppear {
-                flow.subscribe(perform: stateChanged)
+                Task {
+                    await flow.subscribe(perform: stateChanged)
+                }
             }
     }
 }

--- a/Packages/FlowKit/Sources/FlowKitTestSupport/StatefulTestCase.swift
+++ b/Packages/FlowKit/Sources/FlowKitTestSupport/StatefulTestCase.swift
@@ -75,20 +75,6 @@ public extension StatefulTestCase {
         try await task(flow)
     }
 
-    /// Asserts that the flow's current state matches an expected state.
-    /// - Parameter expectedState: The expected state that the flow should be in.
-    /// - Parameter message: An optional message for the assertion if it fails.
-    func expectState(matches expectedState: TestableFlow.State, message: String = "") {
-        XCTAssertEqual(self.flow?.state, expectedState, message)
-    }
-
-    /// Asserts that the flow's current state doesn't match an expected state.
-    /// - Parameter expectedState: The expected state that the flow should not be in.
-    /// - Parameter message: An optional message for the assertion if it fails.
-    func expectState(doesNotMatch expectedState: TestableFlow.State, message: String = "") {
-        XCTAssertNotEqual(self.flow?.state, expectedState, message)
-    }
-
     /// Emits an event and waits for a period of time, ensuring that the event has succeeded.
     /// - Parameter event: The event to emit and wait on.
     /// - Parameter time: The time interval that the test will wait for.
@@ -105,9 +91,7 @@ public extension StatefulTestCase {
         }
         await self.fulfillment(of: [expectation], timeout: timeout)
     }
-}
 
-public extension StatefulTestCase where TestableFlow: Actor {
     /// Asserts that the flow's current state matches an expected state.
     /// - Parameter expectedState: The expected state that the flow should be in.
     /// - Parameter message: An optional message for the assertion if it fails.

--- a/Packages/FlowKit/Tests/FlowKitTests/Dummy.swift
+++ b/Packages/FlowKit/Tests/FlowKitTests/Dummy.swift
@@ -15,13 +15,18 @@
 import FlowKit
 import SwiftUI
 
-class DummyFlow: StatefulFlowProviding {
+actor DummyFlow: StatefulFlowProviding {
     var state: State { internalState }
 
     var onStateChange: ((State) -> Void)?
+    var stateSubscribers = [((State) -> Void)]()
 
     private var internalState: State = .initial {
-        didSet { onStateChange?(internalState) }
+        didSet {
+            stateSubscribers.forEach { callback in
+                callback(internalState)
+            }
+        }
     }
 
     enum State {

--- a/Packages/FrugalMode/Sources/FrugalMode/FrugalModeFlow.swift
+++ b/Packages/FrugalMode/Sources/FrugalMode/FrugalModeFlow.swift
@@ -17,7 +17,7 @@ import FlowKit
 import Foundation
 
 /// A flow designed to assess the state of frugal mode in an app.
-public class FrugalModeFlow: ObservableObject {
+public actor FrugalModeFlow: ObservableObject {
     public enum State {
         /// The initial state of the flow, which indicates nothing has occurred.
         case initial

--- a/Packages/FrugalMode/Sources/FrugalMode/FrugalModeFlow.swift
+++ b/Packages/FrugalMode/Sources/FrugalMode/FrugalModeFlow.swift
@@ -38,9 +38,14 @@ public actor FrugalModeFlow: ObservableObject {
     }
 
     public var onStateChange: ((State) -> Void)?
+    public var stateSubscribers = [((State) -> Void)]()
 
     @Published var internalState: State = .initial {
-        didSet { onStateChange?(internalState) }
+        didSet {
+            stateSubscribers.forEach { callback in
+                callback(internalState)
+            }
+        }
     }
 
     public init() {}

--- a/Packages/FrugalMode/Tests/FrugalModeTests/FrugalModeTests.swift
+++ b/Packages/FrugalMode/Tests/FrugalModeTests/FrugalModeTests.swift
@@ -18,7 +18,7 @@ final class FrugalModeFlowTests: XCTestCase, StatefulTestCase {
     func testEmitCheckedOverrides() async throws {
         await withCheckedFlow { currentFlow in
             await currentFlow.emit(.checkOverrides)
-            XCTAssertEqual(currentFlow.state, .userDefaults)
+            await self.expectState(matches: .userDefaults)
         }
     }
 
@@ -31,7 +31,7 @@ final class FrugalModeFlowTests: XCTestCase, StatefulTestCase {
             }
             await self.fulfillment(of: [expectation], timeout: 10)
             await currentFlow.emit(.reset)
-            XCTAssertEqual(currentFlow.state, .initial)
+            await self.expectState(matches: .initial)
         }
     }
 }

--- a/Packages/GardenGate/Sources/GardenGate/AuthenticationGate.swift
+++ b/Packages/GardenGate/Sources/GardenGate/AuthenticationGate.swift
@@ -58,11 +58,13 @@ public actor AuthenticationGate: ObservableObject {
 
     @Published var internalState: State = .initial {
         didSet {
-            onStateChange?(internalState)
+            stateSubscribers.forEach { callback in
+                callback(internalState)
+            }
         }
     }
 
-    public var onStateChange: ((State) -> Void)?
+    public var stateSubscribers = [((State) -> Void)]()
 
     private let app = Alice.OAuth.RegisteredApplication(name: "Fedigardens", website: "https://fedigardens.app")
     private let disallowedDomains: Set<String> = {

--- a/Packages/GardenGate/Sources/GardenGate/AuthenticationGate.swift
+++ b/Packages/GardenGate/Sources/GardenGate/AuthenticationGate.swift
@@ -17,7 +17,7 @@ import Combine
 import FlowKit
 import Foundation
 
-public class AuthenticationGate: ObservableObject {
+public actor AuthenticationGate: ObservableObject {
     public enum AuthenticationError: Error {
         case unitializedGate
         case authorizationInProgress(String)
@@ -81,8 +81,7 @@ public class AuthenticationGate: ObservableObject {
     private var auth: Alice.OAuth
     private var network: Alice
 
-    public init(auth: Alice.OAuth = .shared, network: Alice = .shared) {
-        self.internalState = .initial
+    public init(auth: Alice.OAuth, network: Alice) {
         self.auth = auth
         self.network = network
     }

--- a/Packages/GardenGate/Sources/GardenGate/AuthenticationGateView.swift
+++ b/Packages/GardenGate/Sources/GardenGate/AuthenticationGateView.swift
@@ -22,19 +22,8 @@ public struct AuthenticationGateView: StatefulView {
     @State private var callbackUrl: URL?
     @State private var displayAuthenticationDialog = false
     @State private var displayDomainValidationError = false
+    @State private var domainValidationErrorTitle = ""
     @FocusState private var focusedDomainEntry: Bool
-
-    private var domainValidationTitle: String {
-        switch flow.state {
-        case .error(let cause):
-            if let domainCause = cause as? DomainValidationError {
-                return domainCause.message
-            }
-            return cause.localizedDescription
-        default:
-            return ""
-        }
-    }
 
     public var flow = AuthenticationGate(auth: .shared, network: .shared)
 
@@ -70,7 +59,7 @@ public struct AuthenticationGateView: StatefulView {
                     Text("OK")
                 }.keyboardShortcut(.defaultAction)
             } message: {
-                Text(domainValidationTitle)
+                Text(domainValidationErrorTitle)
             }
     }
 
@@ -79,12 +68,14 @@ public struct AuthenticationGateView: StatefulView {
         case .openAuth(_, let callback):
             self.callbackUrl = callback
             self.displayAuthenticationDialog = true
+            self.domainValidationErrorTitle = ""
         case .error(let cause):
             if cause is DomainValidationError {
                 self.displayDomainValidationError = true
             }
+            self.domainValidationErrorTitle = (cause as? DomainValidationError)?.message ?? cause.localizedDescription
         default:
-            break
+            self.domainValidationErrorTitle = ""
         }
     }
 

--- a/Packages/GardenGate/Tests/GardenGateTests/AuthenticationGateTests.swift
+++ b/Packages/GardenGate/Tests/GardenGateTests/AuthenticationGateTests.swift
@@ -43,9 +43,7 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
     }
 
     func testFlowInitialStateMatches() async throws {
-        await withCheckedFlow { current in
-            XCTAssertEqual(current.state, .initial)
-        }
+        await self.expectState(matches: .initial)
     }
 
     func testFlowDispatchEditEvent() async throws {
@@ -55,7 +53,7 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
             for character in domain {
                 domainString += String(character)
                 await current.emit(.edit(domain: domainString))
-                XCTAssertEqual(current.state, .editing(domain: domainString))
+                await self.expectState(matches: .editing(domain: domainString))
             }
         }
     }
@@ -70,7 +68,7 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
                 expectation.fulfill()
             }
             await self.fulfillment(of: [expectation], timeout: 10)
-            XCTAssertEqual(current.state, .openAuth(domain: domain, callback: URL(string: self.cbString)!))
+            await self.expectState(matches: .openAuth(domain: domain, callback: URL(string: self.cbString)!))
         }
     }
 
@@ -84,7 +82,7 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
                 expectation.fulfill()
             }
             await self.fulfillment(of: [expectation], timeout: 10)
-            XCTAssertEqual(current.state, .error(DomainValidationError.invalid(domain: badURL)))
+            await self.expectState(matches: .error(DomainValidationError.invalid(domain: badURL)))
         }
     }
 
@@ -93,7 +91,7 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
         await withCheckedFlow { current in
             await current.emit(.edit(domain: badURL))
             await current.emit(.getAuthorizationToken)
-            XCTAssertEqual(current.state, .error(DomainValidationError.rejected(domain: badURL)))
+            await self.expectState(matches: .error(DomainValidationError.rejected(domain: badURL)))
             XCTAssertEqual(
                 DomainValidationError.rejected(domain: badURL).message,
                 "Fedigardens cannot sign in to gab.ai because the developers cannot verify that this server moderates"
@@ -104,7 +102,7 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
     func testFlowDispatchErrorOnPrematureAuthorization() async throws {
         await withCheckedFlow { current in
             await current.emit(.getAuthorizationToken)
-            XCTAssertEqual(current.state, .error(AuthenticationGate.AuthenticationError.unitializedGate))
+            await self.expectState(matches: .error(AuthenticationGate.AuthenticationError.unitializedGate))
         }
     }
 
@@ -118,11 +116,11 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
                 expectation.fulfill()
             }
             await self.fulfillment(of: [expectation], timeout: 10)
-            XCTAssertEqual(current.state, .openAuth(domain: domain, callback: URL(string: self.cbString)!))
+            await self.expectState(matches: .openAuth(domain: domain, callback: URL(string: self.cbString)!))
 
             await current.emit(.getAuthorizationToken)
-            XCTAssertEqual(current.state,
-                           .error(AuthenticationGate.AuthenticationError.authorizationInProgress(domain)))
+            await self.expectState(
+                matches: .error(AuthenticationGate.AuthenticationError.authorizationInProgress(domain)))
         }
     }
 
@@ -136,15 +134,15 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
                 expectation.fulfill()
             }
             await self.fulfillment(of: [expectation], timeout: 10)
-            XCTAssertEqual(current.state, .openAuth(domain: domain, callback: URL(string: self.cbString)!))
+            await self.expectState(matches: .openAuth(domain: domain, callback: URL(string: self.cbString)!))
 
             await current.emit(.getAuthorizationToken)
-            XCTAssertEqual(current.state,
-                           .error(AuthenticationGate.AuthenticationError.authorizationInProgress(domain)))
+            await self.expectState(
+                matches: .error(AuthenticationGate.AuthenticationError.authorizationInProgress(domain)))
 
             await current.emit(.getAuthorizationToken)
-            XCTAssertEqual(current.state,
-                           .error(AuthenticationGate.AuthenticationError.authorizationInProgress(domain)))
+            await self.expectState(
+                matches: .error(AuthenticationGate.AuthenticationError.authorizationInProgress(domain)))
         }
     }
 
@@ -155,10 +153,10 @@ final class AuthenticationGateTests: XCTestCase, StatefulTestCase {
             for character in domain {
                 domainString += String(character)
                 await current.emit(.edit(domain: domainString))
-                XCTAssertEqual(current.state, .editing(domain: domainString))
+                await self.expectState(matches: .editing(domain: domainString))
             }
             await current.emit(.reset)
-            XCTAssertEqual(current.state, .initial)
+            await self.expectState(matches: .initial)
         }
     }
 }

--- a/Packages/Interventions/Sources/Interventions/InterventionFlow.swift
+++ b/Packages/Interventions/Sources/Interventions/InterventionFlow.swift
@@ -67,10 +67,14 @@ public actor InterventionFlow<Opener: InterventionLinkOpener>: ObservableObject 
         case reset
     }
 
-    public var onStateChange: ((State) -> Void)?
+    public var stateSubscribers = [((State) -> Void)]()
 
     @Published var internalState: State = .initial {
-        didSet { onStateChange?(internalState) }
+        didSet {
+            stateSubscribers.forEach { callback in
+                callback(internalState)
+            }
+        }
     }
 
     private let oneSecUrl = URL(string: "onesec://reintervene?appId=fedigardens")!

--- a/Packages/Interventions/Sources/Interventions/InterventionFlow.swift
+++ b/Packages/Interventions/Sources/Interventions/InterventionFlow.swift
@@ -33,13 +33,13 @@ public actor InterventionFlow<Opener: InterventionLinkOpener>: ObservableObject 
         case authorizedIntervention(Date, context: InterventionAuthorizationContext)
 
         /// An error has occurred.
-        case error(Error)
+        case error(InterventionRequestError)
 
-        public static func == (lhs: State, rhs: State) -> Bool {
+        nonisolated public static func == (lhs: State, rhs: State) -> Bool {
             return lhs.hashValue == rhs.hashValue
         }
 
-        public func hash(into hasher: inout Hasher) {
+        nonisolated public func hash(into hasher: inout Hasher) {
             switch self {
             case .initial:
                 hasher.combine("\(State.self)__initial")
@@ -69,7 +69,7 @@ public actor InterventionFlow<Opener: InterventionLinkOpener>: ObservableObject 
 
     public var stateSubscribers = [((State) -> Void)]()
 
-    @Published var internalState: State = .initial {
+    var internalState: State = .initial {
         didSet {
             stateSubscribers.forEach { callback in
                 callback(internalState)


### PR DESCRIPTION
This PR makes a major change with flows in FlowKit, converting them from classes to actors. Using actors can help prevent data races when updating states within a flow.

All existing flows have been updated to actors, and any code that requires running on the main thread has been changed respectively.